### PR TITLE
fix: Implement reset foreground and reset background color escapes.

### DIFF
--- a/src/main/java/li/cil/oc2/common/vm/terminal/TerminalBufferWriter.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/TerminalBufferWriter.java
@@ -49,6 +49,8 @@ class TerminalBufferWriter {
                         terminal.altColorsBackground[index] = terminal.backgroundColor.Copy();
                 case SIXTEEN_COLOR_BRIGHT ->
                         terminal.altColorsBackground[index] = terminal.sixteenColorBright.Copy();
+                case DEFAULT_BACKGROUND ->
+                        terminal.altColorsBackground[index] = TerminalColors.DEFAULT_BACKGROUND_COLOR.Copy();
                 default -> {}
             }
 
@@ -82,6 +84,8 @@ class TerminalBufferWriter {
                         terminal.colorsBackground[index] = terminal.backgroundColor.Copy();
                 case SIXTEEN_COLOR_BRIGHT ->
                         terminal.colorsBackground[index] = terminal.sixteenColorBright.Copy();
+                case DEFAULT_BACKGROUND ->
+                        terminal.colorsBackground[index] = TerminalColors.DEFAULT_BACKGROUND_COLOR.Copy();
                 default -> {}
             }
 

--- a/src/main/java/li/cil/oc2/common/vm/terminal/TerminalColors.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/TerminalColors.java
@@ -98,14 +98,14 @@ public final class TerminalColors {
 
     @SuppressWarnings("unused")
     public static final class Color {
-        static final int BLACK = 0;
-        static final int RED = 1;
-        static final int GREEN = 2;
-        static final int YELLOW = 3;
-        static final int BLUE = 4;
-        static final int MAGENTA = 5;
-        static final int CYAN = 6;
-        static final int WHITE = 7;
+        public static final int BLACK = 0;
+        public static final int RED = 1;
+        public static final int GREEN = 2;
+        public static final int YELLOW = 3;
+        public static final int BLUE = 4;
+        public static final int MAGENTA = 5;
+        public static final int CYAN = 6;
+        public static final int WHITE = 7;
     }
 
     public static class ColorData {

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/SGR.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/SGR.java
@@ -91,9 +91,19 @@ public class SGR extends CSISequenceHandler {
                 terminal.currentForegroundColorMode = TerminalColors.ColorMode.SIXTEEN_COLOR;
                 terminal.sixteenColor.R = arg - 30;
             }
+            case 39 -> { // Default foreground color
+                terminal.currentForegroundColorMode = TerminalColors.ColorMode.SIXTEEN_COLOR;
+                terminal.foregroundColor = TerminalColors.DEFAULT_TRUE_COLOR_FOREGROUND.Copy();
+                terminal.sixteenColor.R = TerminalColors.Color.WHITE;
+            }
             case 40, 41, 42, 43, 44, 45, 46, 47 -> { // Set background color
                 terminal.currentBackgroundColorMode = TerminalColors.ColorMode.SIXTEEN_COLOR;
                 terminal.sixteenColor.G = arg - 40;
+            }
+            case 49 -> { // Default background color
+                terminal.currentBackgroundColorMode = TerminalColors.ColorMode.SIXTEEN_COLOR;
+                terminal.backgroundColor = TerminalColors.DEFAULT_TRUE_COLOR_BACKGROUND.Copy();
+                terminal.sixteenColor.G = TerminalColors.Color.BLACK;
             }
             case 90, 91, 92, 93, 94, 95, 96, 97 -> { // Set foreground color
                 terminal.currentForegroundColorMode = TerminalColors.ColorMode.SIXTEEN_COLOR_BRIGHT;

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/SGR.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/SGR.java
@@ -101,7 +101,7 @@ public class SGR extends CSISequenceHandler {
                 terminal.sixteenColor.G = arg - 40;
             }
             case 49 -> { // Default background color
-                terminal.currentBackgroundColorMode = TerminalColors.ColorMode.SIXTEEN_COLOR;
+                terminal.currentBackgroundColorMode = TerminalColors.ColorMode.DEFAULT_BACKGROUND;
                 terminal.backgroundColor = TerminalColors.DEFAULT_TRUE_COLOR_BACKGROUND.Copy();
                 terminal.sixteenColor.G = TerminalColors.Color.BLACK;
             }


### PR DESCRIPTION
## Description

Implement reset foreground and reset background escapes in terminal escape handler.

## Checklist

- `./gradlew build` passes (Yes.)
- Public API changes are documented with JavaDoc (No public API change)
- No `// comments` or SPDX headers in new code (Comment follows rest of file)
- Files follow ≤200 lines, ≤4 per folder rules (Minor addition to file)
