### PR TITLE
fix: insert/delete char/line for VT100 compliance (vttest suite 8)

### DIFF
--- a/src/main/java/li/cil/oc2/common/vm/terminal/buffer/TerminalBufferWriter.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/buffer/TerminalBufferWriter.java
@@ -1,5 +1,6 @@
 package li.cil.oc2.common.vm.terminal.buffer;
 
+import java.util.Arrays;
 import li.cil.oc2.common.vm.terminal.Terminal;
 import li.cil.oc2.common.vm.terminal.color.TerminalColors;
 import li.cil.oc2.common.vm.terminal.escapes.index.NEL;
@@ -20,6 +21,53 @@ public class TerminalBufferWriter {
             } else {
                 terminal.setCursorPos(Terminal.WIDTH - 1, terminal.y);
             }
+        }
+
+        if (terminal.currentModeState.IRM) {
+            // Insert mode: shift line right from cursor position, then place char
+            int charsToInsert = 1;
+            int startIndex =
+                    ((terminal.currentPrivateModeState.isAltBufferEnabled())
+                                    ? terminal.y * Terminal.WIDTH
+                                    : (terminal.y + (terminal.lastRowToDisplayMax - Terminal.HEIGHT))
+                                            * Terminal.WIDTH)
+                            + terminal.x;
+            int count = Terminal.WIDTH - terminal.x - charsToInsert;
+            if (count > 0) {
+                TerminalColors.ColorData c;
+                switch (terminal.currentBackgroundColorMode) {
+                    case SIXTEEN_COLOR -> c = terminal.sixteenColor;
+                    case TWO_FIFTY_SIX_COLOR -> c = terminal.twoFiftySixColor;
+                    case TRUE_COLOR -> c = terminal.backgroundColor;
+                    case SIXTEEN_COLOR_BRIGHT -> c = terminal.sixteenColorBright;
+                    case DEFAULT_BACKGROUND -> c = TerminalColors.DEFAULT_BACKGROUND_COLOR;
+                    default -> c = TerminalColors.DEFAULT_BACKGROUND_COLOR;
+                }
+                if (terminal.currentPrivateModeState.isAltBufferEnabled()) {
+                    System.arraycopy(terminal.altBuffer, startIndex, terminal.altBuffer, startIndex + charsToInsert, count);
+                    System.arraycopy(terminal.altColors, startIndex, terminal.altColors, startIndex + charsToInsert, count);
+                    System.arraycopy(terminal.altColorsBackground, startIndex, terminal.altColorsBackground, startIndex + charsToInsert, count);
+                    System.arraycopy(terminal.altStyles, startIndex, terminal.altStyles, startIndex + charsToInsert, count);
+                    Arrays.fill(terminal.altBuffer, startIndex, startIndex + charsToInsert, ' ');
+                    Arrays.fill(terminal.altColors, startIndex, startIndex + charsToInsert, TerminalColors.DEFAULT_COLORS.Copy());
+                    Arrays.fill(terminal.altColorsBackground, startIndex, startIndex + charsToInsert, c.Copy());
+                    Arrays.fill(terminal.altStyles, startIndex, startIndex + charsToInsert, TerminalColors.DEFAULT_STYLE);
+                } else {
+                    System.arraycopy(terminal.buffer, startIndex, terminal.buffer, startIndex + charsToInsert, count);
+                    System.arraycopy(terminal.colors, startIndex, terminal.colors, startIndex + charsToInsert, count);
+                    System.arraycopy(terminal.colorsBackground, startIndex, terminal.colorsBackground, startIndex + charsToInsert, count);
+                    System.arraycopy(terminal.styles, startIndex, terminal.styles, startIndex + charsToInsert, count);
+                    Arrays.fill(terminal.buffer, startIndex, startIndex + charsToInsert, ' ');
+                    Arrays.fill(terminal.colors, startIndex, startIndex + charsToInsert, TerminalColors.DEFAULT_COLORS.Copy());
+                    Arrays.fill(terminal.colorsBackground, startIndex, startIndex + charsToInsert, c.Copy());
+                    Arrays.fill(terminal.styles, startIndex, startIndex + charsToInsert, TerminalColors.DEFAULT_STYLE);
+                }
+            }
+            /* Mark the row dirty so the renderer redraws shifted cells */
+            terminal.renderers.forEach(
+                    model ->
+                            model.getDirtyMask()
+                                    .accumulateAndGet(1 << terminal.y, (prev, next) -> prev | next));
         }
 
         setChar(terminal.x, terminal.y, ch);

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH10.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH10.java
@@ -58,17 +58,17 @@ public class CH10 extends CSISequenceHandler { // Combined Handler 10 (DCH and X
                         terminal.altStyles,
                         startIndex,
                         count);
-                Arrays.fill(terminal.altBuffer, endIndex, endIndex + chars + 1, ' ');
+                Arrays.fill(terminal.altBuffer, endIndex, endIndex + chars, ' ');
                 Arrays.fill(
                         terminal.altColors,
                         endIndex,
-                        endIndex + chars + 1,
+                        endIndex + chars,
                         TerminalColors.DEFAULT_COLORS.Copy());
-                Arrays.fill(terminal.altColorsBackground, endIndex, endIndex + chars + 1, c.Copy());
+                Arrays.fill(terminal.altColorsBackground, endIndex, endIndex + chars, c.Copy());
                 Arrays.fill(
                         terminal.altStyles,
                         endIndex,
-                        endIndex + chars + 1,
+                        endIndex + chars,
                         TerminalColors.DEFAULT_STYLE);
             } else {
                 System.arraycopy(
@@ -83,17 +83,17 @@ public class CH10 extends CSISequenceHandler { // Combined Handler 10 (DCH and X
                         count);
                 System.arraycopy(
                         terminal.styles, startIndex + chars, terminal.styles, startIndex, count);
-                Arrays.fill(terminal.buffer, endIndex, endIndex + chars + 1, ' ');
+                Arrays.fill(terminal.buffer, endIndex, endIndex + chars, ' ');
                 Arrays.fill(
                         terminal.colors,
                         endIndex,
-                        endIndex + chars + 1,
+                        endIndex + chars,
                         TerminalColors.DEFAULT_COLORS.Copy());
-                Arrays.fill(terminal.colorsBackground, endIndex, endIndex + chars + 1, c.Copy());
+                Arrays.fill(terminal.colorsBackground, endIndex, endIndex + chars, c.Copy());
                 Arrays.fill(
                         terminal.styles,
                         endIndex,
-                        endIndex + chars + 1,
+                        endIndex + chars,
                         TerminalColors.DEFAULT_STYLE);
             }
 

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH11.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH11.java
@@ -13,15 +13,13 @@ public class CH11 extends CSISequenceHandler { // Combined Handler 10 (ICH and S
     public void execute(final int[] args, final int argsCount, final CSIState state) {
         int chars = Math.max(args[0], 1);
         if (state.space) { // SL
-            for (int i = 0; i <= terminal.y; i++) {
+            chars = Math.min(chars, Terminal.WIDTH);
+            for (int i = terminal.scrollFirst; i <= terminal.scrollLast; i++) {
                 shiftLeft(chars, i);
             }
         } else { // ICH
-            if (chars >= Terminal.WIDTH) {
-                terminal.bufferManager.clearLine(terminal.y);
-            } else {
-                shiftRight(chars);
-            }
+            chars = Math.min(chars, Terminal.WIDTH - terminal.x);
+            shiftRight(chars);
         }
     }
 


### PR DESCRIPTION
## Description

- DCH (CH10): fix off-by-one in Arrays.fill — was clearing chars+1 cells, should clear exactly 'chars' cells at end of shifted region.

- ICH (CH11): clamp chars to Terminal.WIDTH - terminal.x instead of clearing whole line when chars >= WIDTH. Simplified: always call shiftRight, which handles full-width correctly when clamped.

- SL (CH11): fix line range — was iterating 0..terminal.y, should iterate scrollFirst..scrollLast. Also clamp chars to Terminal.WIDTH.

- IRM (TerminalBufferWriter): implement insert mode in putChar. When IRM is set (SM 4), shift line right from cursor before placing char, discarding the rightmost cell. Previously IRM was a no-op.

Note: IRM block follows existing alt/main buffer duplication pattern (CH10, CH11, TerminalLineShifter). This is intentionally consistent with the codebase — the screen-features branch includes a refactor that consolidates these into a shared helper.

VTTEST suite 8 (insert/delete char/line) now passes bringing our score to 23/100

This enables all editing features and allows us to work correctly in VT102 mode

Assisted by: Aether Silverstone (OpenClaw agent — code generation, review, and VT100 spec analysis).

- `./gradlew build` passes [Yes]
- Public API changes are documented with JavaDoc [No changes]
- `//` comments only where they explain complex logic or important modules [Yes]
- No SPDX headers in new code [Yes]
- Files follow ≤200 lines, ≤4 per folder rules [Yes]
