### PR TITLE
chore: dedupe RIS saved-cursor resets after SGR PR merge

### DIFF
--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/index/RIS.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/index/RIS.java
@@ -33,9 +33,8 @@ public class RIS {
         terminal.drawingModeG0 = TerminalColors.DrawingMode.ASCII;
         terminal.drawingModeG1 = TerminalColors.DrawingMode.ASCII;
         terminal.useG0 = true;
-        // Reset saved cursor state (DECSC/DECRC)
-        terminal.savedX = 0;
-        terminal.savedY = 0;
+        // Reset saved style/charset/color state (DECSC/DECRC). Saved cursor coords
+        // (savedX/Y, altSavedX/Y) are already reset above.
         terminal.savedStyle = TerminalColors.DEFAULT_STYLE;
         terminal.savedUseG0 = true;
         terminal.savedDrawingModeG0 = TerminalColors.DrawingMode.ASCII;
@@ -47,8 +46,6 @@ public class RIS {
         terminal.savedTwoFiftySixColor = TerminalColors.DEFAULT_256_COLORS.copy();
         terminal.savedForegroundColor = TerminalColors.DEFAULT_TRUE_COLOR_FOREGROUND.copy();
         terminal.savedBackgroundColor = TerminalColors.DEFAULT_TRUE_COLOR_BACKGROUND.copy();
-        terminal.altSavedX = 0;
-        terminal.altSavedY = 0;
         terminal.altSavedStyle = TerminalColors.DEFAULT_STYLE;
         terminal.altSavedUseG0 = true;
         terminal.altSavedDrawingModeG0 = TerminalColors.DrawingMode.ASCII;


### PR DESCRIPTION
The VT100 audit (be838ab) and the SGR color-parser PR (#8) both added saved-cursor resets to RIS.execute, developed in parallel off the same base. After the merge, savedX/savedY/altSavedX/altSavedY were reset twice — once by the audit's block, once by the SGR PR's saved-state block.

Drop the four redundant lines from the SGR PR's block (the audit's earlier reset already handles them) and update the comment to reflect that the remaining block resets saved style/charset/color. No behavior change.

Assisted by: GLM (syn:large:text on synthetic.new) — code generation and review.

## Checklist

- [x] `./gradlew build` passes
- [x] Public API changes are documented with JavaDoc
- [x] `//` comments only where they explain complex logic or important modules
- [x] No SPDX headers in new code
- [x] Files follow ≤200 lines, ≤4 per folder rules
