### PR TITLE
refactor: adopt deleteChars/insertChars in DCH/ICH (CH10/CH11); fix shared helper dirty-mark for scrollback

### DIFF
--- a/src/main/java/li/cil/oc2/common/vm/terminal/buffer/TerminalBuffer.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/buffer/TerminalBuffer.java
@@ -227,10 +227,15 @@ public class TerminalBuffer {
     }
 
     private void markDirty(final int y) {
+        // Map the screen row to its dirty bit via getDirtyRow, mirroring setChar, so a char
+        // op on row y marks the screen row where that buffer row currently renders — including
+        // the scrollback offset (lastRowToDisplayMax - lastRowToDisplay). Plain 1 << y would
+        // mark the wrong visible row when the view is scrolled back into scrollback.
+        final int dirtyBit = 1 << TerminalBufferWriter.getDirtyRow(terminal, y);
         terminal.renderers.forEach(
                 model ->
                         model.getDirtyMask()
-                                .accumulateAndGet(1 << y, (left, right) -> left | right));
+                                .accumulateAndGet(dirtyBit, (left, right) -> left | right));
     }
 
     public void incrementLastLineToDisplay() {

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH10.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH10.java
@@ -1,9 +1,6 @@
 package li.cil.oc2.common.vm.terminal.escapes.csi;
 
-import java.util.Arrays;
 import li.cil.oc2.common.vm.terminal.Terminal;
-import li.cil.oc2.common.vm.terminal.buffer.TerminalBufferWriter;
-import li.cil.oc2.common.vm.terminal.color.TerminalColors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -23,91 +20,10 @@ public class CH10 extends CSISequenceHandler { // Combined Handler 10 (DCH and X
     public void execute(final int[] args, final int argsCount, final CSIState state) {
         if (state.hash) { // XTPUSHCOLORS
             LOGGER.warn("XTPUSHCOLORS not implemented");
-        } else { // DCH
-            int chars = Math.min(args[0], Terminal.WIDTH - terminal.x);
-            int startIndex =
-                    (terminal.currentPrivateModeState.isAltBufferEnabled()
-                                    ? terminal.y * Terminal.WIDTH
-                                    : (terminal.y
-                                                    + terminal.lastRowToDisplayMax
-                                                    - Terminal.HEIGHT)
-                                            * Terminal.WIDTH)
-                            + terminal.x;
-            int count = Terminal.WIDTH - terminal.x - chars;
-            int endIndex = startIndex + count;
-            TerminalColors.ColorData c;
-            switch (terminal.currentBackgroundColorMode) {
-                case SIXTEEN_COLOR -> c = terminal.sixteenColor;
-                case TWO_FIFTY_SIX_COLOR -> c = terminal.twoFiftySixColor;
-                case TRUE_COLOR -> c = terminal.backgroundColor;
-                case SIXTEEN_COLOR_BRIGHT -> c = terminal.sixteenColorBright;
-                default -> c = TerminalColors.DEFAULT_BACKGROUND_COLOR;
-            }
-            if (terminal.currentPrivateModeState.isAltBufferEnabled()) {
-                System.arraycopy(
-                        terminal.altBuffer,
-                        startIndex + chars,
-                        terminal.altBuffer,
-                        startIndex,
-                        count);
-                System.arraycopy(
-                        terminal.altColors,
-                        startIndex + chars,
-                        terminal.altColors,
-                        startIndex,
-                        count);
-                System.arraycopy(
-                        terminal.altColorsBackground,
-                        startIndex + chars,
-                        terminal.altColorsBackground,
-                        startIndex,
-                        count);
-                System.arraycopy(
-                        terminal.altStyles,
-                        startIndex + chars,
-                        terminal.altStyles,
-                        startIndex,
-                        count);
-                Arrays.fill(terminal.altBuffer, endIndex, endIndex + chars, ' ');
-                Arrays.fill(
-                        terminal.altColors,
-                        endIndex,
-                        endIndex + chars,
-                        TerminalColors.DEFAULT_FOREGROUND_COLOR.copy());
-                Arrays.fill(terminal.altColorsBackground, endIndex, endIndex + chars, c.copy());
-                Arrays.fill(
-                        terminal.altStyles,
-                        endIndex,
-                        endIndex + chars,
-                        TerminalColors.DEFAULT_STYLE);
-            } else {
-                System.arraycopy(
-                        terminal.buffer, startIndex + chars, terminal.buffer, startIndex, count);
-                System.arraycopy(
-                        terminal.colors, startIndex + chars, terminal.colors, startIndex, count);
-                System.arraycopy(
-                        terminal.colorsBackground,
-                        startIndex + chars,
-                        terminal.colorsBackground,
-                        startIndex,
-                        count);
-                System.arraycopy(
-                        terminal.styles, startIndex + chars, terminal.styles, startIndex, count);
-                Arrays.fill(terminal.buffer, endIndex, endIndex + chars, ' ');
-                Arrays.fill(
-                        terminal.colors,
-                        endIndex,
-                        endIndex + chars,
-                        TerminalColors.DEFAULT_FOREGROUND_COLOR.copy());
-                Arrays.fill(terminal.colorsBackground, endIndex, endIndex + chars, c.copy());
-                Arrays.fill(
-                        terminal.styles,
-                        endIndex,
-                        endIndex + chars,
-                        TerminalColors.DEFAULT_STYLE);
-            }
-
-            terminal.markDirty(1 << TerminalBufferWriter.getDirtyRow(terminal, terminal.y));
+        } else { // DCH — Delete Character: shift remaining chars left, blank the tail
+            // deleteChars clamps count to the remaining width, fills with the current
+            // background / DEFAULT_FOREGROUND, and marks the rendered screen row dirty.
+            terminal.bufferManager.deleteChars(terminal.y, terminal.x, args[0]);
         }
     }
 }

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH11.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH11.java
@@ -1,11 +1,8 @@
 package li.cil.oc2.common.vm.terminal.escapes.csi;
 
-import java.util.Arrays;
 import li.cil.oc2.common.vm.terminal.Terminal;
-import li.cil.oc2.common.vm.terminal.buffer.TerminalBufferWriter;
-import li.cil.oc2.common.vm.terminal.color.TerminalColors;
 
-public class CH11 extends CSISequenceHandler { // Combined Handler 10 (ICH and SL)
+public class CH11 extends CSISequenceHandler { // Combined Handler 11 (ICH and SL)
     public CH11(final Terminal terminal) {
         super(terminal);
     }
@@ -17,148 +14,14 @@ public class CH11 extends CSISequenceHandler { // Combined Handler 10 (ICH and S
 
     @Override
     public void execute(final int[] args, final int argsCount, final CSIState state) {
-        int chars = args[0];
-        if (state.space) { // SL
-            chars = Math.min(chars, Terminal.WIDTH);
+        if (state.space) { // SL — Scroll-Left: shift each scroll-region row left, blank the right
             for (int i = terminal.scrollFirst; i <= terminal.scrollLast; i++) {
-                shiftLeft(chars, i);
+                terminal.bufferManager.deleteChars(i, 0, args[0]);
             }
-        } else { // ICH
-            chars = Math.min(chars, Terminal.WIDTH - terminal.x);
-            shiftRight(chars);
+        } else { // ICH — Insert Character: shift chars right from the cursor, blank the gap
+            // insertChars clamps count to the remaining width, fills with the current
+            // background / DEFAULT_FOREGROUND, and marks the rendered screen row dirty.
+            terminal.bufferManager.insertChars(terminal.y, terminal.x, args[0]);
         }
-    }
-
-    private void shiftLeft(int chars, int y) {
-        int startIndex =
-                terminal.currentPrivateModeState.isAltBufferEnabled()
-                        ? y * Terminal.WIDTH
-                        : (y + terminal.lastRowToDisplayMax - Terminal.HEIGHT) * Terminal.WIDTH;
-        int count = Terminal.WIDTH - chars;
-        int endIndex = startIndex + count;
-        TerminalColors.ColorData c;
-        switch (terminal.currentBackgroundColorMode) {
-            case SIXTEEN_COLOR -> c = terminal.sixteenColor;
-            case TWO_FIFTY_SIX_COLOR -> c = terminal.twoFiftySixColor;
-            case TRUE_COLOR -> c = terminal.backgroundColor;
-            case SIXTEEN_COLOR_BRIGHT -> c = terminal.sixteenColorBright;
-            default -> c = TerminalColors.DEFAULT_BACKGROUND_COLOR;
-        }
-        if (terminal.currentPrivateModeState.isAltBufferEnabled()) {
-            System.arraycopy(
-                    terminal.altBuffer, startIndex + chars, terminal.altBuffer, startIndex, count);
-            System.arraycopy(
-                    terminal.altColors, startIndex + chars, terminal.altColors, startIndex, count);
-            System.arraycopy(
-                    terminal.altColorsBackground,
-                    startIndex + chars,
-                    terminal.altColorsBackground,
-                    startIndex,
-                    count);
-            System.arraycopy(
-                    terminal.altStyles, startIndex + chars, terminal.altStyles, startIndex, count);
-
-            Arrays.fill(terminal.altBuffer, endIndex, endIndex + chars, ' ');
-            Arrays.fill(
-                    terminal.altColors,
-                    endIndex,
-                    endIndex + chars,
-                    TerminalColors.DEFAULT_FOREGROUND_COLOR.copy());
-            Arrays.fill(terminal.altColorsBackground, endIndex, endIndex + chars, c.copy());
-            Arrays.fill(
-                    terminal.altStyles, endIndex, endIndex + chars, TerminalColors.DEFAULT_STYLE);
-        } else {
-            System.arraycopy(
-                    terminal.buffer, startIndex + chars, terminal.buffer, startIndex, count);
-            System.arraycopy(
-                    terminal.colors, startIndex + chars, terminal.colors, startIndex, count);
-            System.arraycopy(
-                    terminal.colorsBackground,
-                    startIndex + chars,
-                    terminal.colorsBackground,
-                    startIndex,
-                    count);
-            System.arraycopy(
-                    terminal.styles, startIndex + chars, terminal.styles, startIndex, count);
-
-            Arrays.fill(terminal.buffer, endIndex, endIndex + chars, ' ');
-            Arrays.fill(
-                    terminal.colors,
-                    endIndex,
-                    endIndex + chars,
-                    TerminalColors.DEFAULT_FOREGROUND_COLOR.copy());
-            Arrays.fill(terminal.colorsBackground, endIndex, endIndex + chars, c.copy());
-            Arrays.fill(terminal.styles, endIndex, endIndex + chars, TerminalColors.DEFAULT_STYLE);
-        }
-
-        terminal.markDirty(1 << TerminalBufferWriter.getDirtyRow(terminal, y));
-    }
-
-    private void shiftRight(int chars) {
-        int startIndex =
-                (terminal.currentPrivateModeState.isAltBufferEnabled()
-                                ? terminal.y * Terminal.WIDTH
-                                : (terminal.y + terminal.lastRowToDisplayMax - Terminal.HEIGHT)
-                                        * Terminal.WIDTH)
-                        + terminal.x;
-        int count = Terminal.WIDTH - terminal.x - chars;
-        TerminalColors.ColorData c;
-        switch (terminal.currentBackgroundColorMode) {
-            case SIXTEEN_COLOR -> c = terminal.sixteenColor;
-            case TWO_FIFTY_SIX_COLOR -> c = terminal.twoFiftySixColor;
-            case TRUE_COLOR -> c = terminal.backgroundColor;
-            case SIXTEEN_COLOR_BRIGHT -> c = terminal.sixteenColorBright;
-            default -> c = TerminalColors.DEFAULT_BACKGROUND_COLOR;
-        }
-        if (terminal.currentPrivateModeState.isAltBufferEnabled()) {
-            System.arraycopy(
-                    terminal.altBuffer, startIndex, terminal.altBuffer, startIndex + chars, count);
-            System.arraycopy(
-                    terminal.altColors, startIndex, terminal.altColors, startIndex + chars, count);
-            System.arraycopy(
-                    terminal.altColorsBackground,
-                    startIndex,
-                    terminal.altColorsBackground,
-                    startIndex + chars,
-                    count);
-            System.arraycopy(
-                    terminal.altStyles, startIndex, terminal.altStyles, startIndex + chars, count);
-            Arrays.fill(terminal.altBuffer, startIndex, startIndex + chars, ' ');
-            Arrays.fill(
-                    terminal.altColors,
-                    startIndex,
-                    startIndex + chars,
-                    TerminalColors.DEFAULT_FOREGROUND_COLOR.copy());
-            Arrays.fill(terminal.altColorsBackground, startIndex, startIndex + chars, c.copy());
-            Arrays.fill(
-                    terminal.altStyles,
-                    startIndex,
-                    startIndex + chars,
-                    TerminalColors.DEFAULT_STYLE);
-        } else {
-            System.arraycopy(
-                    terminal.buffer, startIndex, terminal.buffer, startIndex + chars, count);
-            System.arraycopy(
-                    terminal.colors, startIndex, terminal.colors, startIndex + chars, count);
-            System.arraycopy(
-                    terminal.colorsBackground,
-                    startIndex,
-                    terminal.colorsBackground,
-                    startIndex + chars,
-                    count);
-            System.arraycopy(
-                    terminal.styles, startIndex, terminal.styles, startIndex + chars, count);
-            Arrays.fill(terminal.buffer, startIndex, startIndex + chars, ' ');
-            Arrays.fill(
-                    terminal.colors,
-                    startIndex,
-                    startIndex + chars,
-                    TerminalColors.DEFAULT_FOREGROUND_COLOR.copy());
-            Arrays.fill(terminal.colorsBackground, startIndex, startIndex + chars, c.copy());
-            Arrays.fill(
-                    terminal.styles, startIndex, startIndex + chars, TerminalColors.DEFAULT_STYLE);
-        }
-
-        terminal.markDirty(1 << TerminalBufferWriter.getDirtyRow(terminal, terminal.y));
     }
 }

--- a/src/test/java/li/cil/oc2/common/vm/terminal/TerminalBufferTest.java
+++ b/src/test/java/li/cil/oc2/common/vm/terminal/TerminalBufferTest.java
@@ -633,6 +633,29 @@ public class TerminalBufferTest {
         assertEquals('A', charAt(1, 0), "with IRM off, writes overwrite in place");
     }
 
+    // --- Char ops while scrolled back must mark the rendered screen row (getDirtyRow) ---
+
+    @Test
+    void echWhileScrolledBackMarksCorrectScreenRow() {
+        // Grow scrollback so lastRowToDisplayMax exceeds HEIGHT; the view stays at the bottom
+        // (lastRowToDisplay == lastRowToDisplayMax), which alone does not expose the bug.
+        for (int i = 0; i < 30; i++) write(terminal, "\n");
+        // Scroll the view one line back into scrollback. The cursor's bottom-window row now
+        // renders (lastRowToDisplayMax - lastRowToDisplay) screen rows below terminal.y.
+        buffer.decrementLastLineToDisplay();
+        final int scrollBack = terminal.lastRowToDisplayMax - terminal.lastRowToDisplay;
+        assertTrue(scrollBack >= 1, "view should be scrolled back into scrollback");
+        // Cursor to the top row; its buffer row is still visible and renders at row scrollBack.
+        write(terminal, "\u001b[1;1H");
+        write(terminal, "ABCDEFGH");
+        write(terminal, "\u001b[1;1H");
+        resetDirty();
+        write(terminal, "\u001b[2X"); // ECH 2: erase 2 chars at the cursor, no shift
+        // The erased buffer row renders at screen row scrollBack, not at row 0 (terminal.y).
+        assertEquals(1 << scrollBack, renderer.dirtyMask.get() & 0xFFFFFF,
+            "ECH while scrolled back must mark the screen row where the cursor row renders, not terminal.y");
+    }
+
     @Test
     void decscnmToggleMarksWholeScreenDirty() {
         assertFalse(terminal.currentPrivateModeState.DECSCNM);

--- a/src/test/java/li/cil/oc2/common/vm/terminal/TerminalBufferTest.java
+++ b/src/test/java/li/cil/oc2/common/vm/terminal/TerminalBufferTest.java
@@ -657,6 +657,89 @@ public class TerminalBufferTest {
     }
 
     @Test
+    void dchWhileScrolledBackMarksCorrectScreenRow() {
+        for (int i = 0; i < 30; i++) write(terminal, "\n");
+        buffer.decrementLastLineToDisplay();
+        final int scrollBack = terminal.lastRowToDisplayMax - terminal.lastRowToDisplay;
+        assertTrue(scrollBack >= 1, "view should be scrolled back into scrollback");
+        write(terminal, "\u001b[1;1H");
+        write(terminal, "ABCDEFGH");
+        write(terminal, "\u001b[1;1H");
+        resetDirty();
+        write(terminal, "\u001b[2P"); // DCH 2: delete 2, shift left, blank the tail
+        assertEquals(1 << scrollBack, renderer.dirtyMask.get() & 0xFFFFFF,
+            "DCH while scrolled back must mark the screen row where the cursor row renders, not terminal.y");
+    }
+
+    @Test
+    void ichWhileScrolledBackMarksCorrectScreenRow() {
+        for (int i = 0; i < 30; i++) write(terminal, "\n");
+        buffer.decrementLastLineToDisplay();
+        final int scrollBack = terminal.lastRowToDisplayMax - terminal.lastRowToDisplay;
+        assertTrue(scrollBack >= 1, "view should be scrolled back into scrollback");
+        write(terminal, "\u001b[1;1H");
+        write(terminal, "ABCDEFGH");
+        write(terminal, "\u001b[1;1H");
+        resetDirty();
+        write(terminal, "\u001b[2@"); // ICH 2: insert 2 blanks, shift right
+        assertEquals(1 << scrollBack, renderer.dirtyMask.get() & 0xFFFFFF,
+            "ICH while scrolled back must mark the screen row where the cursor row renders, not terminal.y");
+    }
+
+    // --- DCH/ICH arg-0 (normalized to 1 by the dispatcher) and arg-overflow (clamped to width) ---
+
+    @Test
+    void dchArgZeroDeletesOneChar() {
+        // CSIManager replaces arg 0 with the default (1) before the handler runs, so an
+        // explicit 0 deletes exactly one character rather than being a no-op.
+        write(terminal, "ABCDEFGH");
+        write(terminal, "\u001b[3G");    // x=2 (C)
+        write(terminal, "\u001b[0P");     // DCH 0 -> delete 1
+        assertEquals('A', charAt(0, 0));
+        assertEquals('B', charAt(1, 0));
+        assertEquals('D', charAt(2, 0), "arg 0 is normalized to 1, deleting one char");
+        assertEquals('E', charAt(3, 0));
+        assertEquals('H', charAt(6, 0));
+        assertEquals(' ', charAt(7, 0), "the freed tail cell is blanked");
+    }
+
+    @Test
+    void ichArgZeroInsertsOne() {
+        write(terminal, "ABCDEFGH");
+        write(terminal, "\u001b[3G");    // x=2 (C)
+        write(terminal, "\u001b[0@");     // ICH 0 -> insert 1
+        assertEquals('A', charAt(0, 0));
+        assertEquals('B', charAt(1, 0));
+        assertEquals(' ', charAt(2, 0), "arg 0 is normalized to 1, inserting one blank");
+        assertEquals('C', charAt(3, 0), "existing chars shift right by one");
+        assertEquals('D', charAt(4, 0));
+    }
+
+    @Test
+    void dchArgOverflowClearsToEndOfLine() {
+        write(terminal, "ABCDEFGH");
+        write(terminal, "\u001b[3G");    // x=2 (C)
+        write(terminal, "\u001b[999P");   // DCH 999 -> clamp to width, clear to end of line
+        assertEquals('A', charAt(0, 0));
+        assertEquals('B', charAt(1, 0));
+        for (int x = 2; x < Terminal.WIDTH; x++) {
+            assertEquals(' ', charAt(x, 0), "overflow count clears from the cursor to end of line");
+        }
+    }
+
+    @Test
+    void ichArgOverflowBlanksToEndOfLine() {
+        write(terminal, "ABCDEFGH");
+        write(terminal, "\u001b[3G");    // x=2 (C)
+        write(terminal, "\u001b[999@");   // ICH 999 -> clamp to width, blank to end of line
+        assertEquals('A', charAt(0, 0));
+        assertEquals('B', charAt(1, 0));
+        for (int x = 2; x < Terminal.WIDTH; x++) {
+            assertEquals(' ', charAt(x, 0), "overflow count blanks from the cursor to end of line");
+        }
+    }
+
+    @Test
     void decscnmToggleMarksWholeScreenDirty() {
         assertFalse(terminal.currentPrivateModeState.DECSCNM);
         resetDirty();


### PR DESCRIPTION
Follow-up to #10 (screen-features). CH10 (DCH) and CH11 (ICH/SL) each inlined the same character shift+fill/color switch that `TerminalBuffer.deleteChars`/`insertChars` already provide, so the two implementations would drift — and `deleteChars` was dead code. This adopts the helpers and removes the inline duplicates.

## Commits

**1. `fix: buffer helper markDirty maps the cursor row to its rendered screen row via getDirtyRow`**

`TerminalBuffer.markDirty` used a plain `1 << y`, so `clearChars`/`insertChars`/`deleteChars` marked bit `terminal.y` instead of the screen row where that buffer row renders. When the view is scrolled back into scrollback (`lastRowToDisplay < lastRowToDisplayMax`), the cursor's bottom-window row renders `y + (Max − Display)` rows lower, so the **wrong visible row was marked dirty** — the same stale-row class as #10's `shiftLines` fix (c858266). Route `markDirty` through `getDirtyRow` (mirroring `setChar`); the alt-buffer and at-bottom (`Max == Display`) cases are unchanged. This also fixes the latent form in the already-wired helpers (`clearChars` → ECH/ED/EL/DL, `insertChars` → IRM) and makes the DCH/ICH swap below non-regressing.

**2. `refactor: adopt deleteChars/insertChars in DCH (CH10) and ICH/SL (CH11), drop the inline shift`**

- CH10 DCH → `deleteChars(terminal.y, terminal.x, args[0])`
- CH11 ICH → `insertChars(terminal.y, terminal.x, args[0])`
- CH11 SL → `deleteChars(i, 0, args[0])` per scroll-region row — `shiftLeft` was the same operation from column 0, so it dedups too.

The helpers clamp count to the remaining width and fill with the current background / DEFAULT_FOREGROUND, matching the old inline code, so behavior is unchanged — including the dispatcher's `0 → default(1)` arg normalization and the overflow → clear-to-end path. `deleteChars` goes from dead code to first use. Removes `shiftLeft`/`shiftRight` and ~140 lines; the shift+fill logic now lives only in `TerminalBuffer`.

## Tests
- ECH/DCH/ICH while scrolled back must mark the **rendered** screen row (guards the #10-blocker regression class — verified to FAIL with the plain `1 << y`, PASS with `getDirtyRow`).
- DCH/ICH arg-0 deletes/inserts one (pins the dispatcher's 0→1 normalization).
- DCH/ICH arg-overflow clears/blanks to end of line (pins the helper's `remaining<=0 → clearChars` path).

## Two corrections to the originally-queued follow-up analysis
- **arg-0 is a non-issue.** `CSIManager.executeHandler` replaces `args[i]==0` with the default before the handler runs (CH10/CH11 default to 1), so the handler never sees `0`; the helper's `max(count,1)` is a redundant no-op.
- **The dirty-mark bug was in the helper, not the inline code.** The inline CH10/CH11 used the correct `getDirtyRow`; the helpers' plain `1<<y` was the buggy one (opposite of what a prior note guessed).

## QA gate
Checkstyle: 0 violations. SpotBugs: no new findings (the 449 main / 2 test bugs are pre-existing; none in the touched files). PMD: one new `AvoidDuplicateLiterals` on `"ABCDEFGH"` in `TerminalBufferTest` (now 11×, was 4×; threshold is 9+). Left as-is for now — a separate follow-up can extract an `ESC` constant and dedup the test literals.

Assisted by: GLM (syn:large:text on synthetic.new) — code generation and review.