### PR TITLE
refactor: drop redundant min-1 clamp in TerminalBuffer.deleteChars/insertChars

### DIFF
--- a/src/main/java/li/cil/oc2/common/vm/terminal/buffer/TerminalBuffer.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/buffer/TerminalBuffer.java
@@ -92,7 +92,8 @@ public class TerminalBuffer {
      * characters left and filling blanks at the end.
      */
     public void deleteChars(final int y, final int x, final int count) {
-        final int n = Math.min(Math.max(count, 1), Terminal.WIDTH - x);
+        final int n = Math.max(Math.min(count, Terminal.WIDTH - x), 0);
+        if (n == 0) return;
         final int remaining = Terminal.WIDTH - x - n;
         if (remaining <= 0) {
             clearChars(y, x, Terminal.WIDTH - x);
@@ -164,7 +165,8 @@ public class TerminalBuffer {
      * existing characters right. Characters pushed past the line width are lost.
      */
     public void insertChars(final int y, final int x, final int count) {
-        final int n = Math.min(Math.max(count, 1), Terminal.WIDTH - x);
+        final int n = Math.max(Math.min(count, Terminal.WIDTH - x), 0);
+        if (n == 0) return;
         final int remaining = Terminal.WIDTH - x - n;
         if (remaining <= 0) {
             clearChars(y, x, Terminal.WIDTH - x);


### PR DESCRIPTION
Tiny follow-up to #12 that missed the merge (it was on the branch as an amend after #12 was merged from draft).

`deleteChars`/`insertChars` clamped `count` with `Math.min(Math.max(count, 1), WIDTH - x)`, forcing a minimum of 1. That minimum is redundant: every caller already supplies a valid count —
- CH10/CH11 get `args[0] >= 1` because `CSIManager` normalizes a `0` argument to the handler default (`1`) before the handler runs, and
- `TerminalBufferWriter` passes a hardcoded `1` for IRM insert-mode typing.

So `Math.max(count, 1)` always returned `count`. Drop the force-min-1 and clamp only to the width, matching `clearChars`'s shape (`Math.max(Math.min(count, WIDTH - x), 0)` with an early return on `0`). This puts the bounds responsibility in the caller — the dispatcher owns arg normalization there — and leaves the helper enforcing only its own invariant (width). A future `0` caller becomes a safe empty no-op rather than silently deleting one char.

No behavior change at any current call site — the existing arg-0 and arg-overflow tests (added in #12) still pass via the dispatcher's `0 -> 1` normalization. QA gate clean (no new Checkstyle/PMD/SpotBugs findings in `TerminalBuffer`).

Assisted by: GLM (syn:large:text on synthetic.new) — code generation and review.