### PR TITLE
fix: DECCOLM resets SGR attributes and erases to default background

### DIFF
--- a/src/main/java/li/cil/oc2/common/vm/terminal/Terminal.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/Terminal.java
@@ -145,6 +145,23 @@ public class Terminal {
         return HEIGHT * CHAR_HEIGHT;
     }
 
+    /**
+     * Reset the current rendition to defaults — SGR attributes, color modes, and the active
+     * color palette — as DECCOLM (VT100–VT420) does. Does not touch saved DECSC/DECRC state
+     * (that's RIS/DECSC's domain). Must run before setWidth so the buffer erase fills with
+     * the default background, not whatever SGR background was active when the mode change hit.
+     */
+    public void resetRendition() {
+        currentForegroundColorMode = ColorMode.DEFAULT_FOREGROUND;
+        currentBackgroundColorMode = ColorMode.DEFAULT_BACKGROUND;
+        sixteenColor = TerminalColors.DEFAULT_COLORS.copy();
+        sixteenColorBright = TerminalColors.DEFAULT_BRIGHT_COLORS.copy();
+        backgroundColor = TerminalColors.DEFAULT_TRUE_COLOR_BACKGROUND.copy();
+        foregroundColor = TerminalColors.DEFAULT_TRUE_COLOR_FOREGROUND.copy();
+        twoFiftySixColor = TerminalColors.DEFAULT_256_COLORS.copy();
+        style = TerminalColors.DEFAULT_STYLE;
+    }
+
     public int getTerminalWidth() {
         return width;
     }

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH2.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH2.java
@@ -43,11 +43,14 @@ public class CH2 extends CSISequenceHandler {
         final Map<ModeTable, Consumer<Terminal>> actions = new EnumMap<>(ModeTable.class); // NOPMD immutable after init
         actions.put(ModeTable.DECCOLM, terminal -> {
             terminal.currentPrivateModeState.DECCOLM = true;
-            /* DECCOLM spec: switch to 132 columns, clear screen, reset margins, home cursor.
-               Deliberately unconditional: VT100 through VT420 always perform the full reset,
-               and legacy software (All-in-1, DECNOTES, the OpenVMS terminal driver) relies on
-               the destructive clear. The non-destructive path is DECSET 95 (DECNCSM) on VT510+,
-               to be added separately; the modern replacement is DECSCPP (CSI Ps $|). */
+            /* DECCOLM spec: switch to 132 columns, clear screen, reset margins, home cursor,
+               and reset SGR attributes. Deliberately unconditional: VT100 through VT420 always
+               perform the full reset, and legacy software (All-in-1, DECNOTES, the OpenVMS
+               terminal driver) relies on the destructive clear. resetRendition runs before
+               setWidth so the screen erases to the default background, not the prior SGR bg.
+               The non-destructive path is DECSET 95 (DECNCSM) on VT510+, to be added separately;
+               the modern replacement is DECSCPP (CSI Ps $|). */
+            terminal.resetRendition();
             terminal.setWidth(132);
         });
         actions.put(ModeTable.DECOM, terminal -> {

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH3.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH3.java
@@ -63,8 +63,10 @@ public class CH3 extends CSISequenceHandler { // Combined Handler 3 (RM & DECRST
 
     private void resetDECCOLM() {
         terminal.currentPrivateModeState.DECCOLM = false;
-        /* DECCOLM spec: switch to 80 columns, clear screen, reset margins, home cursor.
-           Deliberately unconditional — see the matching note in CH2's DECCOLM action. */
+        /* DECCOLM spec: switch to 80 columns, clear screen, reset margins, home cursor, and
+           reset SGR attributes. resetRendition runs before setWidth so the screen erases to the
+           default background — see the matching note in CH2's DECCOLM action. */
+        terminal.resetRendition();
         terminal.setWidth(Terminal.WIDTH);
     }
 

--- a/src/test/java/li/cil/oc2/common/vm/terminal/TerminalBufferTest.java
+++ b/src/test/java/li/cil/oc2/common/vm/terminal/TerminalBufferTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * All sequences below are fed through the real {@link TerminalIO}/{@link TerminalOutput}
  * state machine (the same path the VM firmware uses) via {@code putOutput}.
  */
+@SuppressWarnings("PMD.CyclomaticComplexity") // class-aggregate complexity is high because this is a growing
+// suite of many small @Test methods — that's the point of a test class
 public class TerminalBufferTest {
     private Terminal terminal;
     private TerminalBuffer buffer;
@@ -839,6 +841,31 @@ public class TerminalBufferTest {
             "RIS must reset the column width to the 80-column default, not leave it at 132");
     }
 
+    @Test
+    void deccolmResetsSgrAttributesAndErasesToDefaultBackground() {
+        // DECCOLM (VT100–VT420) is a destructive reset: it clears SGR attributes and erases the
+        // screen to the DEFAULT background, not the SGR background that was active. Contrast with
+        // ECH (echErasedCellsTakeDefaultForegroundAndCurrentBackground), which keeps current bg.
+        write(terminal, CSI + "41m");    // bg = SIXTEEN_COLOR red (sixteenColor.G = 1)
+        write(terminal, SAMPLE_LINE);
+        assertEquals(TerminalColors.ColorMode.SIXTEEN_COLOR, terminal.currentBackgroundColorMode,
+            "precondition: SGR bg is set");
+
+        write(terminal, CSI + "?3h");    // DECCOLM -> 132 columns, destructive reset
+        assertEquals(TerminalColors.ColorMode.DEFAULT_BACKGROUND, terminal.currentBackgroundColorMode,
+            "DECCOLM resets the background color mode to default");
+        assertEquals(TerminalColors.ColorMode.DEFAULT_FOREGROUND, terminal.currentForegroundColorMode,
+            "DECCOLM resets the foreground color mode to default");
+        assertEquals(TerminalColors.DEFAULT_STYLE, terminal.style,
+            "DECCOLM resets SGR attributes (style)");
+
+        final int idx = cellIndex(0, 0);
+        assertEquals(TerminalColors.ColorMode.DEFAULT_BACKGROUND, terminal.colorsBackground[idx].Mode,
+            "cleared cell background must be the DEFAULT background, not the prior SGR red");
+        assertEquals(' ', (char) terminal.buffer[idx],
+            "cleared cell must be a space");
+    }
+
     private void write(final Terminal target, final String text) {
         target.io.putOutput(ByteBuffer.wrap(text.getBytes(StandardCharsets.UTF_8)));
     }
@@ -856,7 +883,7 @@ public class TerminalBufferTest {
 
     private int cellIndex(final int x, final int y) {
         final int row = y + terminal.lastRowToDisplayMax - Terminal.HEIGHT;
-        return x + row * Terminal.WIDTH;
+        return x + row * terminal.width;
     }
 
     private char altCharAt(final int x, final int y) {


### PR DESCRIPTION
Draft for commentary. Built on #16's DECCOLM work and loki's `274bbee` revert (unconditional reset per VT100–VT420).

Per the idempotency discussion: DECCOLM also needs to **reset SGR attributes and erase to the DEFAULT background**, not the SGR background that was active when the mode change hit. The VT525 manual describes DECCOLM as a destructive soft reset (clears all SGR attributes, resets buffers), distinct from ECH (which keeps the current background). vttest's `tst_DECNCSM` confirms "Screen should be cleared" with DECNCSM off (the default, our target).

## What this does
- `Terminal.resetRendition()` — resets the current color modes + palette + style byte (the RIS-subset DECCOLM owns; saved DECSC/DECRC state is not touched).
- CH2 (`?3h`) and CH3 (`?3l`) call `resetRendition()` before `setWidth()`, so the buffer erase fills with the default background as a consequence — the same shape RIS already uses (it resets modes before `setWidth`). `setWidth`'s erase-semantic is unchanged; the difference is DECCOLM now resets the rendition state that determines what "current" means.

## Why not just change setWidth's fill
RIS already relies on `setWidth` filling with "current bg" — RIS resets the modes first, so "current" = default there. Matching that shape keeps `setWidth` a pure geometry+erase operation and puts the rendition reset in the DECCOLM handler where it belongs. The fill-color question resolves itself: with the modes reset first, the default-vs-current distinction goes away.

## Verification
- 155 tests, 0 failures. New `deccolmResetsSgrAttributesAndErasesToDefaultBackground`: sets bg=red, fires `?3h`, asserts color modes/style reset to default and the cleared cell is `DEFAULT_BACKGROUND` (not SGR red). Contrasts with ECH (keeps current bg).
- Revert-and-fail spot-checked: removing `resetRendition` fails at "DECCOLM resets the background color mode to default".
- QA gate: PMD 0, Checkstyle 0, Spotbugs 0 new in changed files. Suppressed PMD `CyclomaticComplexity` on the test class via `@SuppressWarnings` (matching `Ipv4SpaceTest`'s convention — a growing suite of small `@Test` methods).
- Also fixes `cellIndex()` to use `terminal.width` (was `Terminal.WIDTH`) so color assertions index correctly at 132 columns — the new test needs it.

Assisted by: GLM (syn:large:text on synthetic.new) — code generation and review.