### PR TITLE
fix: replace phantom-column autowrap with real autowrapPending flag

### DIFF
--- a/src/main/java/li/cil/oc2/common/vm/terminal/Terminal.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/Terminal.java
@@ -62,6 +62,14 @@ public class Terminal {
     public int scrollLast = HEIGHT - 1;
     public int x;
     public int y;
+    /**
+     * Autowrap-pending flag (DEC autowrap; xterm's {@code do_wrap}): set when a printable
+     * fills the last column — the cursor stays at {@code width-1} and the wrap (NEL) fires
+     * on the <em>next</em> printable, not the current one. Every cursor repositioning clears
+     * it (matching xterm's {@code ResetWrap}), so the cursor never sits at a phantom
+     * column {@code width}. Transient: a restored cursor must not carry a pending wrap.
+     */
+    public transient boolean autowrapPending;
     public int savedX;
     public int savedY;
     public byte savedStyle;
@@ -217,6 +225,7 @@ public class Terminal {
     }
 
     public void setCursorPos(final int x, final int y) {
+        autowrapPending = false; // any explicit cursor move clears the pending wrap (xterm ResetWrap)
         this.x = Math.clamp(x, 0, width - 1);
         this.y = Math.clamp(y, 0, HEIGHT - 1);
     }

--- a/src/main/java/li/cil/oc2/common/vm/terminal/TerminalOutput.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/TerminalOutput.java
@@ -102,6 +102,7 @@ class TerminalOutput {
     }
 
     private void handleTab() {
+        terminal.autowrapPending = false; // Tab is a cursor move — clears the pending wrap (xterm ResetWrap)
         if (terminal.x < terminal.width - 1) {
             do {
                 terminal.x++;

--- a/src/main/java/li/cil/oc2/common/vm/terminal/buffer/TerminalBufferWriter.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/buffer/TerminalBufferWriter.java
@@ -14,11 +14,15 @@ public class TerminalBufferWriter {
     public void putChar(final int ch) {
         if (Character.isISOControl(ch)) return;
 
-        if (terminal.x >= terminal.width) {
+        // Deferred autowrap: if the previous printable filled the last column it left the
+        // cursor at width-1 with autowrapPending set. Fire the wrap now, on THIS printable,
+        // not the one that filled the margin — so the margin char survives and any control
+        // char (BS/CR/Tab) between the two prints can clear the pending wrap instead.
+        if (terminal.autowrapPending) {
             if (terminal.currentPrivateModeState.DECAWM) {
-                NEL.execute(terminal);
+                NEL.execute(terminal); // moves to (0, y+1) and clears pending via setCursorPos
             } else {
-                terminal.setCursorPos(terminal.width - 1, terminal.y);
+                terminal.autowrapPending = false; // DECAWM off: overwrite the last column
             }
         }
 
@@ -28,7 +32,15 @@ public class TerminalBufferWriter {
         }
 
         setChar(terminal.x, terminal.y, ch);
-        terminal.x++;
+        // Fill the last column: arm the pending wrap and hold the cursor at width-1
+        // (never advance to a phantom width). Otherwise advance normally.
+        if (terminal.x == terminal.width - 1) {
+            if (terminal.currentPrivateModeState.DECAWM) {
+                terminal.autowrapPending = true;
+            }
+        } else {
+            terminal.x++;
+        }
     }
 
     public void setChar(final int x, final int y, final int ch) { // NOPMD: data-driven foreground/background color-mode switches

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/DECRC.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/DECRC.java
@@ -4,6 +4,7 @@ import li.cil.oc2.common.vm.terminal.Terminal;
 
 public class DECRC {
     public static void execute(Terminal terminal) {
+        terminal.autowrapPending = false; // restoring the cursor clears any pending wrap
         if (terminal.currentPrivateModeState.isAltBufferEnabled()) {
             terminal.x = terminal.altSavedX;
             terminal.y = terminal.altSavedY;

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH3.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH3.java
@@ -69,6 +69,7 @@ public class CH3 extends CSISequenceHandler { // Combined Handler 3 (RM & DECRST
     }
 
     private void restoreSavedCursor() {
+        terminal.autowrapPending = false; // restoring the cursor clears any pending wrap
         if (terminal.currentPrivateModeState.isAltBufferEnabled()) {
             terminal.x = terminal.altSavedX;
             terminal.y = terminal.altSavedY;

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CSIManager.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CSIManager.java
@@ -84,13 +84,16 @@ public class CSIManager {
     private void handleControlChar(final char ch) { // NOPMD 10-case VT100 control-char dispatch
         switch (ch) {
             case 0x08 -> { /* BS */
+                terminal.autowrapPending = false; // cursor move clears pending (xterm ResetWrap)
                 if (terminal.x > 0) terminal.x--;
             }
             case 0x0D -> { /* CR */
+                terminal.autowrapPending = false; // cursor move clears pending (xterm ResetWrap)
                 terminal.x = 0;
             }
             case 0x0A, 0x0B -> handleControlLineFeed(); /* LF / VT — respect LNM like normal path */
             case 0x09 -> { /* HT */
+                terminal.autowrapPending = false; // cursor move clears pending (xterm ResetWrap)
                 terminal.x = Math.min(terminal.x + 8 - (terminal.x % 8), terminal.width - 1);
             }
             case 0x18, 0x1A -> { /* CAN / SUB — abort CSI sequence */

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/index/IND.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/index/IND.java
@@ -8,7 +8,7 @@ public class IND {
             terminal.bufferManager.shiftUpOne();
             if (!terminal.currentPrivateModeState.isAltBufferEnabled())
                 terminal.bufferManager.incrementLastLineToDisplay();
-            terminal.x = Math.min(terminal.x, terminal.width - 1);
+            terminal.autowrapPending = false; // IND is a cursor move — clears pending (xterm ResetWrap)
         } else {
             terminal.setCursorPos(terminal.x, Math.min(terminal.y + 1, Terminal.HEIGHT - 1));
         }

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/index/RI.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/index/RI.java
@@ -6,6 +6,7 @@ public class RI {
     public static void execute(Terminal terminal) {
         if (terminal.y == terminal.scrollFirst) {
             terminal.bufferManager.shiftDownOne();
+            terminal.autowrapPending = false; // RI is a cursor move — clears pending (xterm ResetWrap)
         } else {
             terminal.setCursorPos(terminal.x, Math.max(terminal.y - 1, 0));
         }

--- a/src/test/java/li/cil/oc2/common/vm/terminal/TerminalBufferTest.java
+++ b/src/test/java/li/cil/oc2/common/vm/terminal/TerminalBufferTest.java
@@ -416,6 +416,37 @@ public class TerminalBufferTest {
     }
 
     @Test
+    void autowrapPendingFlagLifecycle() {
+        // Directly tests the autowrapPending flag's set/clear transitions rather than
+        // inferring them from cell contents (the companion test above does the latter).
+        // This is the state vttest's DECCIR report exposes as the aw_pending bit; the
+        // flag is queried directly here instead of via a terminal-state-report escape.
+
+        // (1) Writing the last column arms pending; the cursor stays at width-1.
+        write(terminal, "A".repeat(Terminal.WIDTH));
+        assertTrue(terminal.autowrapPending, "filling the last column must arm autowrap-pending");
+        assertEquals(Terminal.WIDTH - 1, terminal.x,
+            "cursor must stay at width-1 while pending, not advance to a phantom width");
+
+        // (2) BS clears pending (BS is a cursor move).
+        write(terminal, "\b");
+        assertFalse(terminal.autowrapPending, "BS must clear autowrap-pending");
+
+        // (3) Re-arming pending, then the next printable fires the wrap and clears pending.
+        write(terminal, CSI + "1;1H" + "A".repeat(Terminal.WIDTH)); // home + re-fill row 0
+        assertTrue(terminal.autowrapPending, "re-filling the last column re-arms pending");
+        write(terminal, "B");                                       // fires the deferred wrap
+        assertFalse(terminal.autowrapPending, "the wrap fired by the next printable must clear pending");
+        assertEquals(1, terminal.x, "after the wrap the cursor sits at column 1 (post-write on row 1)");
+
+        // (4) With DECAWM off, filling the last column must NOT arm pending (overwrite, not wrap).
+        write(terminal, CSI + "?7l");
+        write(terminal, CSI + "1;1H" + "A".repeat(Terminal.WIDTH));
+        assertFalse(terminal.autowrapPending,
+            "filling the last column with DECAWM off must not arm pending");
+    }
+
+    @Test
     void dirtyMaskMarksScreenOnScroll() {
         resetDirty();
         write(terminal, CSI + "2S");

--- a/src/test/java/li/cil/oc2/common/vm/terminal/TerminalBufferTest.java
+++ b/src/test/java/li/cil/oc2/common/vm/terminal/TerminalBufferTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.*;
  * All sequences below are fed through the real {@link TerminalIO}/{@link TerminalOutput}
  * state machine (the same path the VM firmware uses) via {@code putOutput}.
  */
+@SuppressWarnings("PMD.CyclomaticComplexity") // class-aggregate complexity is high because this is a growing
+// suite of many small @Test methods — that's the point of a test class
 public class TerminalBufferTest {
     private Terminal terminal;
     private TerminalBuffer buffer;
@@ -391,6 +393,26 @@ public class TerminalBufferTest {
         assertEquals('B', charAt(Terminal.WIDTH - 1, 0));
         assertEquals(' ', charAt(0, 1));
         assertEquals(0, terminal.y);
+    }
+
+    @Test
+    void backspaceFromAutowrapPendingMovesToWidthMinusTwo() {
+        // vttest suite 1, "autowrap, mixing control and print characters" case 1:
+        // fill a row to the right margin (cursor enters autowrap-pending), then BS.
+        // BS must clear pending and move to column width-2 so the next printable
+        // lands one column left of the margin and the just-written margin char
+        // survives; the cursor must not rest at a phantom column width either.
+        // Regressed in 1b978ad, which dropped the pending-aware clamp and made BS
+        // land back on width-1, letting the next printable overwrite the margin.
+        write(terminal, "A".repeat(Terminal.WIDTH)); // fill row 0 to the right margin
+        write(terminal, "\b");                       // BS from autowrap-pending
+        write(terminal, "B");
+        assertEquals('A', charAt(Terminal.WIDTH - 1, 0),
+            "last-column 'A' must survive BS from autowrap-pending");
+        assertEquals('B', charAt(Terminal.WIDTH - 2, 0),
+            "post-BS printable must land at column width-2, not overwrite the margin");
+        assertEquals(Terminal.WIDTH - 1, terminal.x,
+            "cursor must rest at width-1 after the non-margin write, not a phantom width");
     }
 
     @Test


### PR DESCRIPTION
## What's broken

vttest **suite 1, "Test of cursor movements" → the "autowrap, mixing control and print characters" page** (`tst_movements`, the DECAWM demo) misbehaves at **both 80 and 132 columns**. Instead of a clean A–Z down the left margin and a–z down the right (one letter per row), case-1 lowercase letters (`n r v z`) intrude on the **left** margin — each paired with its uppercase sibling (`Nn Rr Vv Zz`) — and the right margin has gaps where cells were blanked.

## Root cause: eager wrap with a phantom column, masked by a workaround

`putChar` did **eager wrap with no pending flag**: it advanced the cursor to a phantom column `width` (`terminal.x++` unconditionally) to encode "autowrap-pending", then compensated for the phantom column with `Math.min(x, width-1)` clamps scattered across the cursor movers. The underlying flaw was the cursor advancing past the last column; the clamps were a workaround masking it.

**`1b978ad`** ("fix: BS at pending wrap moves to column 79") removed the BS clamp, reasoning in its own commit message that "the cursor is logically past column 79, so BS should land on 79." That's correct about its own (wrong) model and wrong about VT: the real VT cursor stays *at* the last column with pending set, and BS clears pending and moves to **width-2**. So `1b978ad` addressed the workaround's surface logic and broke the behavior it was "fixing."

- BS from the phantom column now lands on `width-1` (not `width-2`) → the next printable **overwrites the margin char** (right-margin gaps).
- The cursor re-advances to pending, the wrap fires, and the right-margin letter lands on the **left** margin (the `n r v z` intruders).

**Not a DECCOLM regression** — the eager logic predates `cd66ae9`, which only generalized `Terminal.WIDTH` to the dynamic `terminal.width`. At 80 cols those are equal, so 80-col has always been broken; DECCOLM just extended the same bug to 132.

## The fix

Add a real `transient boolean autowrapPending` flag and drop the phantom-column encoding entirely:

- **`putChar`** consumes pending at the top (NEL if DECAWM, else clear), places the char, and when it fills the last column **holds the cursor at `width-1` and arms the flag** — never advances to a phantom `width`.
- **`setCursorPos` clears the flag** — the chokepoint, matching xterm's `ResetWrap` (which xterm calls at the end of *every* cursor function). Most movers inherit the clear for free.
- **Bypassers** that don't route through `setCursorPos` get explicit clears: `handleTab`, the `IND`/`RI` scroll branches, `DECRC`, `CH3.restoreSavedCursor`, and the CSI-embedded BS/CR/Tab in `CSIManager`. The main `BS`/`CR` handlers need **no change** — they're correct once `x` is never phantom.
- `IND`'s old `Math.min(x, width-1)` phantom clamp became dead code, swapped for the flag clear (its real job had been clearing pending as a side effect of un-phantoming the column).

## Verification

- **Sources**: vttest `vt320.c` (DECCIR reports `autowrap pending` as a separate flag bit, cursor column independent) and **xterm-410** (`screen->do_wrap`: deferred fire on the *next* printable; `CursorBack` `--col` from the last column → width-2; `ResetWrap` in every cursor function).
- **`TerminalBufferTest`: 63/0.** New test `backspaceFromAutowrapPendingMovesToWidthMinusTwo` (fill to margin, BS, print `B`, assert `cell[width-1]=='A' && cell[width-2]=='B'`). Both existing `pendingWrap*` tests stay green — their fill+wrap end-state is identical under eager and deferred, as predicted.
- **Full suite: 165/0** across 17 classes — no mover/scrolling regressions.
- **QA gate passes.** +1 SpotBugs `MALICIOUS_CODE` on the new public `autowrapPending` field — the same category as the 267 existing baseline findings on `Terminal`'s public fields, and the field must be public for cross-package access from `buffer/` and `escapes/`. (Known-issue category for this codebase.) Added the `@SuppressWarnings("PMD.CyclomaticComplexity")` this branch was missing — present on the `deccolm-sgr-reset` branch but not `work` — because the 63rd `@Test` method tips the class over.

## Commit shape (red → green)

1. `a7d623c` — the failing test (deliberately red; revert-and-fail spot-check built into history — check out this commit and run the test to see the bug).
2. `88bba02` — the fix (green).

Assisted by: GLM (syn:large:text on synthetic.new) — code generation and review.

