### PR TITLE
Actually list DECCOLM as available.

### DIFF
--- a/src/main/java/li/cil/oc2/common/vm/terminal/modes/ModeTable.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/modes/ModeTable.java
@@ -25,7 +25,7 @@ public enum ModeTable { // NOPMD: inherently large data-driven 1:1 mode-number l
     // --- DEC private modes (DECSET/DECRST, '?' modifier) ---
     DECCKM(PrivateMode.DECCKM, Kind.PRIVATE, true),
     DECANM(PrivateMode.DECANM, Kind.PRIVATE, false),
-    DECCOLM(PrivateMode.DECCOLM, Kind.PRIVATE, false),
+    DECCOLM(PrivateMode.DECCOLM, Kind.PRIVATE, true),
     DECSCLM(PrivateMode.DECSCLM, Kind.PRIVATE, true),
     DECSCNM(PrivateMode.DECSCNM, Kind.PRIVATE, true),
     DECOM(PrivateMode.DECOM, Kind.PRIVATE, true),


### PR DESCRIPTION
## Description

Setting DECCOLM as a valid private mode was missed during refactor work in work branch
