### PR TITLE
refactor: make Terminal.SCROLL_BACK_COUNT static final

### DIFF
--- a/src/main/java/li/cil/oc2/common/vm/terminal/Terminal.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/Terminal.java
@@ -57,7 +57,7 @@ public class Terminal {
     private transient int lastSentPaletteRevision = -1;
     public byte style;
 
-    public int SCROLL_BACK_COUNT = 20;
+    public static final int SCROLL_BACK_COUNT = 20;
     public transient ByteArrayFIFOQueue input = new ByteArrayFIFOQueue(32);
     // DECCOLM dynamic width; setWidth reallocates buffers. Transient: re-inits to WIDTH on load.
     public transient int width = WIDTH;

--- a/src/main/java/li/cil/oc2/common/vm/terminal/TerminalDiff.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/TerminalDiff.java
@@ -176,7 +176,7 @@ public final class TerminalDiff {
         }
         // Main buffer: the currently displayed scrollback window.
         final int first = Math.max(0, terminal.lastRowToDisplay - Terminal.HEIGHT);
-        final int count = Terminal.HEIGHT * terminal.SCROLL_BACK_COUNT - first;
+        final int count = Terminal.HEIGHT * Terminal.SCROLL_BACK_COUNT - first;
         final int[] rows = new int[Math.min(Terminal.HEIGHT, count)];
         for (int i = 0; i < rows.length; i++) {
             rows[i] = first + i;
@@ -360,7 +360,7 @@ public final class TerminalDiff {
     private static void deserializeRow(
             final Terminal terminal, final boolean alt, final int row, final byte[] data) {
         if (row < 0
-                || (alt ? row >= Terminal.HEIGHT : row >= Terminal.HEIGHT * terminal.SCROLL_BACK_COUNT)) {
+                || (alt ? row >= Terminal.HEIGHT : row >= Terminal.HEIGHT * Terminal.SCROLL_BACK_COUNT)) {
             return;
         }
         final ByteBuffer buf = ByteBuffer.wrap(data).order(ByteOrder.LITTLE_ENDIAN);

--- a/src/main/java/li/cil/oc2/common/vm/terminal/buffer/TerminalBufferScrolling.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/buffer/TerminalBufferScrolling.java
@@ -20,7 +20,7 @@ class TerminalBufferScrolling {
             terminal.lastRowToDisplayMax =
                     Math.min(
                             terminal.lastRowToDisplayMax + 1,
-                            Terminal.HEIGHT * terminal.SCROLL_BACK_COUNT);
+                            Terminal.HEIGHT * Terminal.SCROLL_BACK_COUNT);
         } else if (terminal.lastRowToDisplay == terminal.lastRowToDisplayMax) {
             return;
         }
@@ -53,7 +53,7 @@ class TerminalBufferScrolling {
         if (terminal.currentPrivateModeState.isAltBufferEnabled()) {
             shiftLines(terminal.scrollFirst + 1, terminal.scrollLast, -count);
         } else {
-            if (terminal.lastRowToDisplay == Terminal.HEIGHT * terminal.SCROLL_BACK_COUNT
+            if (terminal.lastRowToDisplay == Terminal.HEIGHT * Terminal.SCROLL_BACK_COUNT
                     || terminal.scrollLast != Terminal.HEIGHT - 1
                     || terminal.scrollFirst != 0) {
                 shiftLines(
@@ -65,7 +65,7 @@ class TerminalBufferScrolling {
                                 : 1,
                         terminal.scrollLast != Terminal.HEIGHT - 1
                                 ? terminal.scrollLast + terminal.lastRowToDisplayMax - Terminal.HEIGHT
-                                : (Terminal.HEIGHT * terminal.SCROLL_BACK_COUNT) - 1,
+                                : (Terminal.HEIGHT * Terminal.SCROLL_BACK_COUNT) - 1,
                         -count);
             }
         }

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH8.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH8.java
@@ -32,7 +32,7 @@ public class CH8
             final int n = Math.min(args[0], Terminal.HEIGHT);
             for (int i = 0; i < n; i++) {
                 if (terminal.lastRowToDisplay
-                        < Terminal.HEIGHT * terminal.SCROLL_BACK_COUNT) {
+                        < Terminal.HEIGHT * Terminal.SCROLL_BACK_COUNT) {
                     terminal.bufferManager.incrementLastLineToDisplay();
                 }
                 terminal.bufferManager.shiftUpOne();

--- a/src/test/java/li/cil/oc2/common/vm/terminal/TerminalBufferTest.java
+++ b/src/test/java/li/cil/oc2/common/vm/terminal/TerminalBufferTest.java
@@ -57,7 +57,7 @@ public class TerminalBufferTest {
         assertEquals(0, terminal.y);
         assertEquals(24, terminal.lastRowToDisplay);
         assertEquals(24, terminal.lastRowToDisplayMax);
-        assertEquals(Terminal.WIDTH * Terminal.HEIGHT * terminal.SCROLL_BACK_COUNT, terminal.buffer.length);
+        assertEquals(Terminal.WIDTH * Terminal.HEIGHT * Terminal.SCROLL_BACK_COUNT, terminal.buffer.length);
         assertEquals(' ', charAt(0, 0));
         assertEquals(' ', charAt(Terminal.WIDTH - 1, Terminal.HEIGHT - 1));
         assertFalse(terminal.currentPrivateModeState.isAltBufferEnabled());
@@ -1442,7 +1442,7 @@ public class TerminalBufferTest {
         write(terminal, CSI + "?3h");
         assertTrue(terminal.currentPrivateModeState.DECCOLM, "?3h enables DECCOLM");
         assertEquals(132, terminal.getTerminalWidth(), "DECCOLM switches to 132 columns");
-        final int expected132 = 132 * Terminal.HEIGHT * terminal.SCROLL_BACK_COUNT;
+        final int expected132 = 132 * Terminal.HEIGHT * Terminal.SCROLL_BACK_COUNT;
         assertEquals(expected132, terminal.buffer.length, "buffers reallocate to 132 columns");
         assertEquals(0xFFFFFF, renderer.dirtyMask.get() & 0xFFFFFF,
             "DECCOLM must redraw the whole screen");
@@ -1464,7 +1464,7 @@ public class TerminalBufferTest {
         write(terminal, CSI + "?3l");
         assertFalse(terminal.currentPrivateModeState.DECCOLM, "?3l disables DECCOLM");
         assertEquals(Terminal.WIDTH, terminal.getTerminalWidth(), "reset returns to 80 columns");
-        final int expected80 = Terminal.WIDTH * Terminal.HEIGHT * terminal.SCROLL_BACK_COUNT;
+        final int expected80 = Terminal.WIDTH * Terminal.HEIGHT * Terminal.SCROLL_BACK_COUNT;
         assertEquals(expected80, terminal.buffer.length, "buffers reallocate back to 80 columns");
     }
 
@@ -1590,7 +1590,7 @@ public class TerminalBufferTest {
         // SD (CSI T) / RI used to arraycopy past the physical buffer end
         // (AIOOBE under lock in putOutput -> terminal dead forever).
         writeMarkers();
-        assertEquals(Terminal.HEIGHT * terminal.SCROLL_BACK_COUNT, terminal.lastRowToDisplayMax,
+        assertEquals(Terminal.HEIGHT * Terminal.SCROLL_BACK_COUNT, terminal.lastRowToDisplayMax,
             "precondition: scrollback filled to cap");
         // Marker two rows above the discarded pair: survives the shift onto the last row.
         final int bottomMarkerRow = Terminal.HEIGHT - 3;
@@ -1630,7 +1630,7 @@ public class TerminalBufferTest {
     private void writeMarkers() {
         // Grow the scrollback window to its hard cap (HEIGHT * SCROLL_BACK_COUNT rows).
         final StringBuilder feed = new StringBuilder();
-        feed.append("\n".repeat(Terminal.HEIGHT * terminal.SCROLL_BACK_COUNT));
+        feed.append("\n".repeat(Terminal.HEIGHT * Terminal.SCROLL_BACK_COUNT));
         write(terminal, feed.toString());
     }
 }


### PR DESCRIPTION
## Summary

`SCROLL_BACK_COUNT` was a `public int` instance field on `Terminal`, but it is never
assigned after declaration — it is a constant that controls scrollback buffer sizing
(buffer allocation, scrollback cap logic, diff row sizing). This makes it
`public static final int`, matching the existing `HEIGHT` convention, and updates the
instance-qualified reads (`terminal.SCROLL_BACK_COUNT`) to class-qualified reads.

No behavior change. No new tests — the existing buffer-sizing tests already assert
against `SCROLL_BACK_COUNT`.

## Why

A public mutable field participating in index arithmetic can be desynchronized from
buffers already allocated with the old value (external mutation after construction →
`ArrayIndexOutOfBoundsException`). `static final` closes that at compile time.

This does not change the SpotBugs baseline: the `MS_SHOULD_BE_FINAL` entries in
`config/spotbugs/baseline.xml` belong to `Config` and `ImplementedPrivateModes`, and
that rule targets static fields, which this never was.

## Verification

Cherry-picked onto `upstream/work` @ `3e48b183` (original branch was five merges back;
applied clean, no conflicts). Clean build in a fresh worktree (no prior build directory):

- `./gradlew clean build` — BUILD SUCCESSFUL
- `:test`: 284 tests, 0 failures, 0 skipped
- PMD main: 0 violations; Checkstyle main: 0 errors; SpotBugs: green

5 files, +12/−12.

Assisted by: GLM (syn:large:text on synthetic.new) — code generation and review.