### PR TITLE
fix: ST-string ESC-abort parity across OSC/DCS/APC

### DIFF
--- a/src/main/java/li/cil/oc2/common/vm/terminal/Terminal.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/Terminal.java
@@ -164,8 +164,8 @@ public class Terminal {
     public transient TerminalBufferWriter bufferWriter;
     transient CSIManager csiManager = new CSIManager(this);
     transient OSCManager oscManager = new OSCManager(this);
-    transient DCSManager dcsManager = new DCSManager(this);
-    transient APCManager apcManager = new APCManager(this);
+    transient DCSManager dcsManager = new DCSManager();
+    transient APCManager apcManager = new APCManager();
     public transient TerminalIO io = new TerminalIO(this);
     private transient TerminalClient clientInstance;
     private final transient ReentrantLock clientLock = new ReentrantLock();

--- a/src/main/java/li/cil/oc2/common/vm/terminal/TerminalOutput.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/TerminalOutput.java
@@ -9,6 +9,7 @@ import li.cil.oc2.common.vm.terminal.color.TerminalColors;
 import li.cil.oc2.common.vm.terminal.escapes.DECRC;
 import li.cil.oc2.common.vm.terminal.escapes.DECSC;
 import li.cil.oc2.common.vm.terminal.escapes.HTS;
+import li.cil.oc2.common.vm.terminal.escapes.StringSequenceHandler;
 import li.cil.oc2.common.vm.terminal.escapes.index.IND;
 import li.cil.oc2.common.vm.terminal.escapes.index.NEL;
 import li.cil.oc2.common.vm.terminal.escapes.index.RI;
@@ -17,7 +18,7 @@ import li.cil.oc2.common.vm.terminal.modes.impl.KeypadMode;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-class TerminalOutput {
+class TerminalOutput { // NOPMD CyclomaticComplexity: dense VT100 state-machine dispatch
 
     private static final Logger LOGGER = LogManager.getLogger();
 
@@ -25,6 +26,11 @@ class TerminalOutput {
 
     private final Terminal terminal;
     private final Utf8Decoder decoder = new Utf8Decoder();
+
+    // True between an ESC seen mid-string (OSC/DCS/APC) and the next byte, while we wait to find
+    // out whether it is '\' (completing ST) or the start of a fresh escape. Owned here, not in the
+    // string managers, so termination is uniform across all three (xterm's single sos_table).
+    private boolean stringEscapePending = false;
 
     TerminalOutput(final Terminal terminal, final ReentrantLock lock) {
         this.terminal = terminal;
@@ -77,13 +83,93 @@ class TerminalOutput {
             case CONTROL_SEQUENCE -> terminal.csiManager.handle(ch);
             case SHIFT_IN_CHARACTER_SET, SHIFT_OUT_CHARACTER_SET -> handleShiftInShiftOut(ch);
             case HASH -> handleHash(ch);
-            case DCS -> terminal.dcsManager.handle(ch);
-            case OSC -> terminal.oscManager.handle(ch);
-            case APC -> terminal.apcManager.handle(ch);
+            case DCS -> handleStringByte(ch, terminal.dcsManager, false);
+            case OSC -> handleStringByte(ch, terminal.oscManager, true);
+            case APC -> handleStringByte(ch, terminal.apcManager, false);
             default -> {
                 // Exhaustive over the known states; guards against future additions.
             }
         }
+    }
+
+    // Drives an ST-terminated string state (OSC/DCS/APC). Termination is owned here, uniformly for
+    // all three, mirroring xterm's single sos_table (VTPrsTbl.c): ESC arms a potential ST, '\'
+    // completes it, BEL ends OSC only, CAN/SUB abort. Content bytes (including '\' not preceded by
+    // ESC) go to the handler's accumulate. On ESC + another byte, xterm leaves esc_table and the
+    // result depends on that byte: '\' completes ST; BEL (CASE_BELL), CAN/SUB (CASE_CAN/CASE_SUB)
+    // are handled above; a fresh escape introducer ([, P, ], _...) or escape final drops the held
+    // string and begins a new sequence (the parsestate != esc_table check at charproc.c:3478 clears
+    // string_used). OC2R's pending branch mirrors the drop-and-begin for those bytes; for the C0
+    // controls xterm would instead execute-and-hold (CASE_BS/TAB/VMOT/CR/SO/SI run the control and
+    // keep the string in esc_table), OC2R aborts-and-redispatches — a stricter, griefer-safe
+    // divergence (a control interleaved into an OSC payload is malformed; dropping it can't be
+    // abused). Re-dispatch is via handleEscape, so e.g. ESC [ mid-OSC starts a CSI rather than
+    // buffering '[' as payload. (For a nested string start ESC P/] xterm's BeginString appends to
+    // the old payload instead of clearing — OC2R's abort-and-start-fresh is the saner divergence.)
+    private void handleStringByte(final char ch, final StringSequenceHandler handler, // NOPMD VT100 string-state byte dispatch; each branch is required
+                                  final boolean belTerminates) {
+        if (stringEscapePending) {
+            if (ch == '\\') {
+                // ST: ESC \ completes the string terminator.
+                stringEscapePending = false;
+                handler.terminate('\\');
+                terminal.state = State.NORMAL;
+            } else if (ch == '\007') {
+                // ESC BEL: xterm CASE_BELL. The ESC moved to esc_table with the string held; for
+                // OSC BEL terminates and processes the payload (charproc.c:3687); for DCS/APC it
+                // rings and keeps the string held in esc_table (charproc.c:3697) — so stay pending:
+                // the ESC is still unresolved, the next byte resolves it.
+                if (belTerminates) {
+                    stringEscapePending = false;
+                    handler.terminate('\007');
+                    terminal.state = State.NORMAL;
+                } else {
+                    terminal.hasPendingBell = true;
+                }
+            } else if (ch == '\030' || ch == '\032') {
+                // ESC CAN / ESC SUB: xterm CASE_CAN/CASE_SUB abort to ground. CAN/SUB are cancel
+                // bytes, not escape introducers, so abort directly — no re-dispatch, which would
+                // otherwise log a spurious "Invalid escape" warning for a legitimate abort byte.
+                stringEscapePending = false;
+                handler.abort();
+                terminal.state = State.NORMAL;
+            } else if (ch != '\033') {
+                // ESC + an escape introducer/final or a C0 control: drop the held string and
+                // re-dispatch the byte through handleEscape (so e.g. ESC [ mid-OSC starts a CSI,
+                // not a buffered '['). For escape introducers/finals this matches xterm's
+                // drop-and-begin; for C0 controls (BS/CR/LF/...) xterm would execute-and-hold —
+                // OC2R aborts instead (stricter, griefer-safe; see method doc). ESC ENQ hits the
+                // "Invalid escape" warn here — pathological, accepted.
+                stringEscapePending = false;
+                handler.abort();
+                handleEscape(ch);
+            }
+            // else ESC ESC: xterm re-enters esc_table with the string held (charproc.c CASE_ESC).
+            // Re-arm (stringEscapePending stays true) and keep waiting — the payload is processed
+            // only if '\' next follows, dropped otherwise. ESCs themselves do not accumulate.
+            return;
+        }
+        if (ch == '\033') {
+            stringEscapePending = true;
+            return;
+        }
+        if (ch == '\007') {
+            if (belTerminates) {
+                handler.terminate('\007');
+                terminal.state = State.NORMAL;
+            } else {
+                // BEL in a non-OSC string rings the bell (xterm CASE_BELL, non-OSC path) without
+                // terminating — DCS/APC continue.
+                terminal.hasPendingBell = true;
+            }
+            return;
+        }
+        if (ch == '\030' || ch == '\032') { // CAN / SUB: abort the string, return to ground.
+            handler.abort();
+            terminal.state = State.NORMAL;
+            return;
+        }
+        handler.accumulate(ch);
     }
 
     // The exact toggle-off bytes: ESC [ ? 7 7 7 7 l  (CSI ? 7777 l). Matched byte-for-byte while
@@ -197,14 +283,17 @@ class TerminalOutput {
             case '#' -> terminal.state = State.HASH;
             case 'P' -> {
                 terminal.dcsManager.reset();
+                stringEscapePending = false;
                 terminal.state = State.DCS;
             }
             case ']' -> {
                 terminal.oscManager.reset();
+                stringEscapePending = false;
                 terminal.state = State.OSC;
             }
             case '_' -> {
                 terminal.apcManager.reset();
+                stringEscapePending = false;
                 terminal.state = State.APC;
             }
             default -> handleSingleCharEscape(ch);

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/StringSequenceHandler.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/StringSequenceHandler.java
@@ -1,0 +1,31 @@
+package li.cil.oc2.common.vm.terminal.escapes;
+
+// Shared contract for the ST-terminated string sequences (OSC, DCS, APC). TerminalOutput owns
+// the termination logic — ESC (the ST introducer), BEL, CAN/SUB — uniformly for all three,
+// mirroring xterm's single sos_table (VTPrsTbl.c): one place decides how a string ends, so the
+// abort/terminate behavior is consistent across OSC/DCS/APC instead of reimplemented (and
+// diverging) in each manager. Each manager owns only what is specific to its sequence type:
+// buffering the payload and, on normal termination, routing it.
+//
+// Bytes reach the manager only AFTER TerminalOutput has ruled out a termination/abort byte.
+// A content byte — including '\', which is content unless it follows ESC — is passed to
+// accumulate. On ST (ESC \) or BEL the manager is told to terminate; on abort (ESC not followed
+// by '\', or CAN/SUB) it is told to abort. xterm drops the accumulated payload on abort rather
+// than processing it (charproc.c: CASE_ESC -> esc_table, then the parsestate != esc_table clear
+// at charproc.c:3478 discards string_used); terminate/abort reflect that distinction.
+public interface StringSequenceHandler {
+    // Buffer a content byte. Implementations bound the buffer so a stream that never terminates
+    // cannot grow unbounded (xterm caps similarly via strings_max).
+    void accumulate(int ch);
+
+    // The string ended normally (ST or BEL). Process the accumulated payload. {@code terminator}
+    // is the byte that ended it — BEL (0x07) or the backslash of ST (0x5C) — so a replying
+    // handler can mirror the query's framing (xterm unparseputc1(xw, final), misc.c:2655).
+    void terminate(int terminator);
+
+    // The string was aborted (ESC + non-'\', or CAN/SUB). Drop the payload without processing.
+    void abort();
+
+    // Clear all state. Called when entering the string state, so a fresh sequence begins clean.
+    void reset();
+}

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/apc/APCManager.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/apc/APCManager.java
@@ -1,24 +1,29 @@
 package li.cil.oc2.common.vm.terminal.escapes.apc;
 
-import li.cil.oc2.common.vm.terminal.Terminal;
+import li.cil.oc2.common.vm.terminal.escapes.StringSequenceHandler;
 
-public class APCManager {
-    private final Terminal terminal;
-    private int lastChar = '\0';
-
-    public APCManager(Terminal terminal) {
-        this.terminal = terminal;
+// APC (Application Program Command, ESC _ ... ST) handler. Stub: xterm ignores APC entirely
+// (charproc.c CASE_ST, ANSI_APC -> "ignored"), and OC2R has no APC use either, so payload bytes
+// are discarded and termination is a no-op. Termination and abort are driven uniformly by
+// TerminalOutput (see StringSequenceHandler); this class exists for symmetry with OSC/DCS and as
+// the attachment point should an APC sequence ever need handling.
+public class APCManager implements StringSequenceHandler {
+    @Override
+    public void accumulate(final int ch) {
+        // APC is ignored; discard payload.
     }
 
-    public void handle(int ch) {
-        if (lastChar == '\033' && ch == '\\') {
-            terminal.state = Terminal.State.NORMAL;
-        } else {
-            lastChar = ch;
-        }
+    @Override
+    public void terminate(final int terminator) {
+        // APC is ignored.
     }
 
+    @Override
+    public void abort() {
+        // Nothing buffered; nothing to drop.
+    }
+
+    @Override
     public void reset() {
-        lastChar = '\0';
     }
 }

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/dcs/DCSManager.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/dcs/DCSManager.java
@@ -1,24 +1,29 @@
 package li.cil.oc2.common.vm.terminal.escapes.dcs;
 
-import li.cil.oc2.common.vm.terminal.Terminal;
+import li.cil.oc2.common.vm.terminal.escapes.StringSequenceHandler;
 
-public class DCSManager {
-    private final Terminal terminal;
-    private int lastChar = '\0';
-
-    public DCSManager(Terminal terminal) {
-        this.terminal = terminal;
+// DCS (Device Control String, ESC P ... ST) handler. Stub: no DCS sequences (e.g. sixel, ReGIS)
+// are implemented yet, so payload bytes are discarded and termination is a no-op. Termination
+// and abort are driven uniformly by TerminalOutput (see StringSequenceHandler); this class is the
+// attachment point for future DCS support, mirroring OSCManager's shape so adding a handler later
+// is a drop-in (a future DCS handler will take the Terminal in its constructor).
+public class DCSManager implements StringSequenceHandler {
+    @Override
+    public void accumulate(final int ch) {
+        // No DCS sequences implemented; discard payload.
     }
 
-    public void handle(int ch) {
-        if (lastChar == '\033' && ch == '\\') {
-            terminal.state = Terminal.State.NORMAL;
-        } else {
-            lastChar = ch;
-        }
+    @Override
+    public void terminate(final int terminator) {
+        // No DCS sequences implemented.
     }
 
+    @Override
+    public void abort() {
+        // Nothing buffered; nothing to drop.
+    }
+
+    @Override
     public void reset() {
-        lastChar = '\0';
     }
 }

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/osc/OSCManager.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/osc/OSCManager.java
@@ -3,60 +3,52 @@ package li.cil.oc2.common.vm.terminal.escapes.osc;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import li.cil.oc2.common.vm.terminal.Terminal;
+import li.cil.oc2.common.vm.terminal.escapes.StringSequenceHandler;
 
-// OSC (Operating System Command, ESC ] ... ST) dispatch. Bytes arrive one at a time from
-// TerminalOutput once the state machine enters the OSC state; this accumulates the payload
-// and, on the ST (ESC \) or BEL terminator, routes it by numeric code to a per-code handler.
-//
-// OSC is an opaque string terminated by ST/BEL, so — unlike CSI — it is only parseable whole,
-// not streaming: the manager buffers the full payload and hands it to the handler on
+// OSC (Operating System Command, ESC ] ... ST) dispatch. TerminalOutput drives the state machine
+// and hands content bytes here once termination has been ruled out; on ST/BEL it calls terminate
+// with the framing byte. This accumulates the payload and routes it by numeric code to a per-code
+// handler. OSC is an opaque string terminated by ST/BEL, so — unlike CSI — it is only parseable
+// whole, not streaming: the manager buffers the full payload and hands it to the handler on
 // termination (xterm accumulates the same way). The handler-per-code split mirrors
 // CSISequenceHandler/CSIManager: a new OSC is a new OSCHandler subclass plus one registration,
 // not a switch arm grown inside the manager. Implemented: OSC 4 (set/query palette entry) and
 // OSC 104 (reset palette entries); the table leaves OSC 0/2/8/10/11 as addable follow-ups.
-public class OSCManager {
+public class OSCManager implements StringSequenceHandler {
     // Bounds the payload buffer so a stream that never terminates can't grow unbounded; 1024
     // is well past any OSC 4/104 payload (a set is ~20 chars). xterm caps similarly. A char[]
     // (not a StringBuilder field) is used because OSCManager lives as long as its Terminal
     // (PMD AvoidStringBufferField).
     private static final int BUFFER_CAP = 1024;
-    private final Terminal terminal;
     private final Map<Integer, OSCHandler> handlers = new ConcurrentHashMap<>();
     private final char[] buffer = new char[BUFFER_CAP];
     private int bufferLength = 0;
-    private int lastChar = '\0';
 
-    public OSCManager(Terminal terminal) {
-        this.terminal = terminal;
+    public OSCManager(final Terminal terminal) {
         handlers.put(4, new OSC4(terminal));
         handlers.put(104, new OSC104(terminal));
     }
 
-    public void handle(int ch) {
-        // ST terminator: ESC followed by '\'. BEL terminator: 0x07. The ESC that begins ST is
-        // armed via lastChar (below) but never buffered, so the payload stays clean. The final
-        // byte (BEL 0x07, or the '\' of ST 0x5C) is passed to processSequence so a replying
-        // handler can mirror the query's framing — xterm's unparseputc1(xw, final) (misc.c:2655).
-        if ((lastChar == '\033' && ch == '\\') || ch == '\007') {
-            processSequence(new String(buffer, 0, bufferLength), (char) ch);
-            bufferLength = 0;
-            lastChar = '\0';
-            terminal.state = Terminal.State.NORMAL;
-            return;
-        }
-        if (ch == '\033') {
-            // Start of the ST terminator — arm lastChar, don't buffer it.
-            lastChar = ch;
-            return;
-        }
+    @Override
+    public void accumulate(final int ch) {
         if (bufferLength < BUFFER_CAP) {
             buffer[bufferLength++] = (char) ch;
         }
-        lastChar = ch;
     }
 
+    @Override
+    public void terminate(final int terminator) {
+        processSequence(new String(buffer, 0, bufferLength), (char) terminator);
+        bufferLength = 0;
+    }
+
+    @Override
+    public void abort() {
+        bufferLength = 0;
+    }
+
+    @Override
     public void reset() {
-        lastChar = '\0';
         bufferLength = 0;
     }
 

--- a/src/test/java/li/cil/oc2/common/vm/terminal/EscapeLiterals.java
+++ b/src/test/java/li/cil/oc2/common/vm/terminal/EscapeLiterals.java
@@ -1,0 +1,33 @@
+package li.cil.oc2.common.vm.terminal;
+
+// Shared VT/ANSI escape-sequence literals for terminal tests.
+//
+// Composable pieces (CSI = ESC + "[") so test sequences read as assemblies of named parts and
+// stay below PMD's AvoidDuplicateLiterals threshold. One source of truth so every terminal test
+// (TerminalBufferTest, SGRTest, StringSequenceTest, ...) names the same bytes.
+//
+// Written via python rather than the Edit/Write tools: those decode the unicode-escape and
+// backslash-escape literals in the payload into control characters instead of writing them as
+// source text.
+public final class EscapeLiterals {
+    private EscapeLiterals() {
+    }
+
+    // Sequence introducers: ESC followed by the introducer byte.
+    public static final String ESC = "\u001b";
+    public static final String CSI = ESC + "[";
+    public static final String OSC = ESC + "]";
+    public static final String DCS = ESC + "P";
+    public static final String APC = ESC + "_";
+
+    // String Terminator (ST): ESC + backslash. Ends OSC/DCS/APC strings.
+    public static final String ST = ESC + "\\";
+
+    // String/data terminators and aborts.
+    public static final String BEL = "\u0007"; // also an OSC terminator (xterm CASE_BELL, OSC path)
+    public static final String CAN = "\u0018"; // cancel: aborts the current sequence (xterm CASE_CAN)
+    public static final String SUB = "\u001a"; // substitute: aborts the current sequence (xterm CASE_SUB)
+
+    // A lone backslash as content (not preceded by ESC) -- distinct from ST, which is ESC + backslash.
+    public static final String BACKSLASH = "\\";
+}

--- a/src/test/java/li/cil/oc2/common/vm/terminal/StringSequenceTest.java
+++ b/src/test/java/li/cil/oc2/common/vm/terminal/StringSequenceTest.java
@@ -1,0 +1,231 @@
+package li.cil.oc2.common.vm.terminal;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static li.cil.oc2.common.vm.terminal.EscapeLiterals.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * ST-terminated string sequences (OSC/DCS/APC): termination + abort parity with xterm.
+ *
+ * <p>xterm handles ESC/ST/BEL/CAN/SUB for all string types in one place — the sos_table
+ * (VTPrsTbl.c) — and OC2R mirrors that with a single {@code TerminalOutput.handleStringByte}.
+ * These tests cover the behaviors the previous per-manager ESC handling got wrong or inconsistent:
+ * ESC + backslash completes ST (regression); BEL terminates OSC only; ESC + a non-backslash byte
+ * drops the held payload and re-dispatches that byte as a fresh escape (ESC [ mid-OSC starts a CSI,
+ * not a buffered '['); CAN/SUB abort; ESC ESC holds the string until the resolving byte; and the
+ * pre-fix swallow (OSC) and stuck-until-ST (DCS/APC) bugs stay fixed.
+ *
+ * <p>Escape bytes come from {@link EscapeLiterals} so the sequences read as named, composable parts.
+ */
+public class StringSequenceTest {
+    private Terminal terminal;
+
+    @BeforeEach
+    void setUp() {
+        terminal = new Terminal();
+    }
+
+    // Reusable OSC 4 payloads (entry 1). Green = the "set applies" cases; red = the "aborted set
+    // must not apply" cases. Composed from the shared EscapeLiterals so the bytes stay single-sourced.
+    private static final String OSC4_SET_1_GREEN = OSC + "4;1;rgb:00/ff/00";
+    private static final String OSC4_SET_1_RED = OSC + "4;1;rgb:ff/00/00";
+
+    @Test
+    void oscStTerminatesAndProcessesPayload() {
+        // Regression: ESC \ (ST) still terminates OSC and processes the payload.
+        final int before = terminal.palette256[1];
+        write(OSC4_SET_1_GREEN + ST);
+        assertEquals(Terminal.State.NORMAL, terminal.state, "ST must return to ground");
+        assertEquals(0x00FF00, terminal.palette256[1], "OSC 4 set via ST must apply");
+        assertNotEquals(before, terminal.palette256[1]);
+    }
+
+    @Test
+    void oscBelTerminatesAndProcessesPayload() {
+        // Regression: BEL terminates OSC (xterm CASE_BELL, OSC path) and processes the payload.
+        write(OSC4_SET_1_GREEN + BEL);
+        assertEquals(Terminal.State.NORMAL, terminal.state, "BEL must terminate OSC");
+        assertEquals(0x00FF00, terminal.palette256[1], "OSC 4 set via BEL must apply");
+    }
+
+    @Test
+    void escBelMidOscTerminatesAndProcessesPayload() {
+        // ESC BEL mid-OSC: the ESC is the transition to esc_table (string held), BEL is CASE_BELL,
+        // which for OSC terminates and processes the payload (charproc.c:3687). The old per-manager
+        // code processed this (its BEL arm was independent of the armed ESC); the centralized handler
+        // must not regress it by dropping the payload on the armed ESC.
+        final int before = terminal.palette256[1];
+        write(OSC4_SET_1_GREEN + ESC + BEL);
+        assertEquals(Terminal.State.NORMAL, terminal.state, "ESC BEL must terminate OSC");
+        assertEquals(0x00FF00, terminal.palette256[1], "OSC 4 set via ESC BEL must apply");
+        assertNotEquals(before, terminal.palette256[1]);
+    }
+
+    @Test
+    void escBelMidDcsRingsAndStaysPending() {
+        // ESC BEL mid-DCS: xterm's CASE_BELL non-OSC path rings and keeps the string held in
+        // esc_table (charproc.c:3697) — it does NOT terminate. So the DCS is still pending: a
+        // following ST (ESC \) completes it. Assert the bell rang, the state stayed DCS, and the
+        // later ST resolves to NORMAL (proving the ESC stayed pending across the BEL).
+        write(DCS + "some-dcs-data" + ESC + BEL);
+        assertTrue(terminal.hasPendingBell, "ESC BEL mid-DCS must ring the bell");
+        assertEquals(Terminal.State.DCS, terminal.state, "ESC BEL must not terminate DCS");
+        write(ST); // the pending ESC now resolves via ST
+        assertEquals(Terminal.State.NORMAL, terminal.state, "ST after ESC BEL must terminate the DCS");
+    }
+
+    @Test
+    void escCanMidOscAbortsAndReturnsToGround() {
+        // ESC CAN mid-OSC: xterm CASE_CAN aborts to ground. CAN is a cancel byte, not an escape
+        // introducer, so it must abort directly (no re-dispatch, no "invalid escape" warning) and
+        // leave the parser in ground for the following CSI.
+        moveCursorToCol4Row4();
+        final int before = terminal.palette256[1];
+        write(OSC4_SET_1_RED + ESC + CAN + CSI + "H"); // ESC CAN aborts, then CUP home
+        assertEquals(Terminal.State.NORMAL, terminal.state, "ESC CAN must abort OSC to ground");
+        assertEquals(before, terminal.palette256[1], "aborted OSC 4 set must not apply");
+        assertEquals(0, terminal.x, "after ESC CAN, ESC [ must start a fresh CSI (CUP home)");
+        assertEquals(0, terminal.y);
+    }
+
+    @Test
+    void escSubMidOscAbortsAndReturnsToGround() {
+        moveCursorToCol4Row4();
+        write(OSC4_SET_1_RED + ESC + SUB + CSI + "H"); // ESC SUB aborts, then CUP home
+        assertEquals(Terminal.State.NORMAL, terminal.state, "ESC SUB must abort OSC to ground");
+        assertEquals(0, terminal.x);
+        assertEquals(0, terminal.y);
+    }
+
+    @Test
+    void escCanMidDcsAbortsAndReturnsToGround() {
+        // CAN/SUB abort is uniform across the string states; pin DCS (only OSC was pinned before).
+        moveCursorToCol4Row4();
+        write(DCS + "some-dcs-data" + ESC + CAN + CSI + "H"); // ESC CAN aborts DCS, then CUP home
+        assertEquals(Terminal.State.NORMAL, terminal.state, "ESC CAN must abort DCS to ground");
+        assertEquals(0, terminal.x, "after ESC CAN, ESC [ must start a fresh CSI (CUP home)");
+        assertEquals(0, terminal.y);
+    }
+
+    @Test
+    void escPNestedDcsStartMidOscAbortsOsc() {
+        // ESC P mid-OSC: the OSC aborts and a fresh DCS begins (OC2R abort-and-start-fresh; xterm's
+        // BeginString would append to the held payload, which OC2R diverges from for sanity). The
+        // OSC payload must NOT apply, and the DCS must then terminate cleanly on ST.
+        final int before = terminal.palette256[1];
+        write(OSC4_SET_1_RED + ESC + "P" + "q"); // ESC P: abort OSC, start DCS, 'q' = sixel
+        assertEquals(Terminal.State.DCS, terminal.state, "ESC P mid-OSC must start a DCS");
+        assertEquals(before, terminal.palette256[1], "aborted OSC payload must not apply");
+        write(ST); // terminate the DCS
+        assertEquals(Terminal.State.NORMAL, terminal.state, "ST must terminate the nested DCS");
+    }
+
+    @Test
+    void escThenNonBackslashAbortsOscAndRedispatchesByte() {
+        // xterm: ESC mid-string -> esc_table; a non-backslash byte drops the held string and begins
+        // a fresh escape. ESC [ mid-OSC must abort the OSC and start a CSI (CUP executes), not
+        // buffer '[' as payload. Pre-fix, OC2R buffered '[' and stayed in OSC (swallow).
+        moveCursorToCol4Row4();
+        write(OSC4_SET_1_RED + CSI + "H"); // OSC aborted by ESC [, then CUP home
+        assertEquals(Terminal.State.NORMAL, terminal.state,
+            "ESC + non-backslash must abort OSC and return to ground");
+        assertEquals(0, terminal.x, "byte after ESC must re-dispatch: ESC [ starts a CSI (CUP home)");
+        assertEquals(0, terminal.y);
+    }
+
+    @Test
+    void abortedOscPayloadIsDropped() {
+        // xterm drops the accumulated payload on abort (charproc.c:3478 clear) — it is NOT
+        // processed. Pre-fix, OC2R kept accumulating and would eventually process a corrupted set.
+        final int before = terminal.palette256[1];
+        write(OSC4_SET_1_RED + CSI + "H"); // aborted: red set must NOT apply
+        assertEquals(before, terminal.palette256[1], "aborted OSC 4 set must not apply");
+        assertEquals(Terminal.State.NORMAL, terminal.state);
+    }
+
+    @Test
+    void dcsEscThenNonBackslashAbortsAndRedispatches() {
+        // Pre-fix: DCS swallowed ESC + non-backslash and stayed in DCS until a real ST arrived
+        // (stuck — a griefer vector in Minecraft). Now it aborts and re-dispatches the byte.
+        moveCursorToCol4Row4();
+        write(DCS + "some-dcs-data" + CSI + "H"); // DCS aborted by ESC [, then CUP home
+        assertEquals(Terminal.State.NORMAL, terminal.state, "ESC + non-backslash must abort DCS");
+        assertEquals(0, terminal.x, "byte after ESC must re-dispatch as CSI (CUP home)");
+        assertEquals(0, terminal.y);
+    }
+
+    @Test
+    void apcEscThenNonBackslashAbortsAndRedispatches() {
+        moveCursorToCol4Row4();
+        write(APC + "some-apc-data" + CSI + "H"); // APC aborted by ESC [, then CUP home
+        assertEquals(Terminal.State.NORMAL, terminal.state, "ESC + non-backslash must abort APC");
+        assertEquals(0, terminal.x, "byte after ESC must re-dispatch as CSI (CUP home)");
+        assertEquals(0, terminal.y);
+    }
+
+    @Test
+    void canAbortsOscAndReturnsToGround() {
+        // xterm CASE_CAN aborts the current sequence; CAN mid-string drops it and returns to
+        // ground, so a following ESC [ starts a fresh CSI. Pre-fix, CAN was buffered as OSC payload.
+        moveCursorToCol4Row4();
+        write(OSC4_SET_1_RED + CAN + CSI + "H"); // CAN aborts, then CUP home
+        assertEquals(Terminal.State.NORMAL, terminal.state, "CAN must abort OSC and return to ground");
+        assertEquals(0, terminal.x, "after CAN, ESC [ must start a fresh CSI (CUP home)");
+        assertEquals(0, terminal.y);
+    }
+
+    @Test
+    void subAbortsOscAndReturnsToGround() {
+        moveCursorToCol4Row4();
+        write(OSC4_SET_1_RED + SUB + CSI + "H"); // SUB aborts, then CUP home
+        assertEquals(Terminal.State.NORMAL, terminal.state, "SUB must abort OSC and return to ground");
+        assertEquals(0, terminal.x);
+        assertEquals(0, terminal.y);
+    }
+
+    @Test
+    void escEscHoldsStringUntilResolvingByte() {
+        // xterm: ESC ESC re-enters esc_table with the string held (charproc.c CASE_ESC). The
+        // payload is processed only if '\' follows (next test), dropped otherwise. Here ESC ESC [
+        // drops the string and starts a CSI.
+        moveCursorToCol4Row4();
+        write(OSC4_SET_1_RED + ESC + CSI + "H"); // ESC ESC [ H: 2nd ESC re-arms, [ aborts, H = CUP
+        assertEquals(Terminal.State.NORMAL, terminal.state);
+        assertEquals(0, terminal.x, "ESC ESC [ must drop the string and start a CSI (CUP home)");
+        assertEquals(0, terminal.y);
+    }
+
+    @Test
+    void escEscThenBackslashCompletesSt() {
+        // xterm: ESC ESC \ — the first ESC enters esc_table, the second re-enters (string held),
+        // '\' completes ST. The accumulated payload is processed (not dropped).
+        write(OSC4_SET_1_GREEN + ESC + ST); // ESC ESC \
+        assertEquals(Terminal.State.NORMAL, terminal.state);
+        assertEquals(0x00FF00, terminal.palette256[1], "ESC ESC + ST must complete ST and process the payload");
+    }
+
+    @Test
+    void backslashAsContentDoesNotTerminate() {
+        // A bare '\' (not preceded by ESC) is content, not ST. It must not terminate the string —
+        // only ESC '\' (ST) does. After a content '\', the state stays in the string until a real
+        // terminator arrives.
+        write(OSC4_SET_1_GREEN + BACKSLASH); // content '\' only, no terminator yet
+        assertEquals(Terminal.State.OSC, terminal.state, "a bare backslash must not terminate OSC");
+        write(ST); // now a real ST
+        assertEquals(Terminal.State.NORMAL, terminal.state, "ST must terminate OSC");
+    }
+
+    private void moveCursorToCol4Row4() {
+        write(CSI + "5;5H"); // CUP row 5 col 5 -> 0-indexed (x=4, y=4)
+        assertEquals(4, terminal.x, "precondition: cursor moved to col 4");
+        assertEquals(4, terminal.y, "precondition: cursor moved to row 4");
+    }
+
+    private void write(final String text) {
+        terminal.io.putOutput(ByteBuffer.wrap(text.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/src/test/java/li/cil/oc2/common/vm/terminal/TerminalBufferTest.java
+++ b/src/test/java/li/cil/oc2/common/vm/terminal/TerminalBufferTest.java
@@ -9,6 +9,7 @@ import li.cil.oc2.common.vm.terminal.render.RendererModel;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static li.cil.oc2.common.vm.terminal.EscapeLiterals.*;
 import static org.junit.jupiter.api.Assertions.*;
 
 /**
@@ -26,14 +27,9 @@ public class TerminalBufferTest {
     private Terminal terminal;
     private TerminalBuffer buffer;
     private DummyRenderer renderer;
-    // Shared test literals: keep these as constants so the many CSI sequences and sample
-    // lines read as composable pieces (CSI = ESC + "[") and stay below PMD's
-    // AvoidDuplicateLiterals threshold.
-    private static final String ESC = "\u001b";
-    private static final String CSI = ESC + "[";
-    private static final String OSC = ESC + "]";
-    private static final String BEL = "\u0007";
-    private static final String ST = ESC + "\\";
+    // Reusable test literals: the escape bytes (ESC/CSI/OSC/BEL/ST) come from the shared
+    // EscapeLiterals (imported statically) so every terminal test names the same bytes; the
+    // sample lines and OSC-4 fixtures below stay here as they are specific to this suite.
     // A reusable OSC 4 set (entry 16 -> red, BEL-terminated) shared across the palette tests so
     // the rgb spec literal stays below PMD's AvoidDuplicateLiterals threshold.
     private static final String RED_RGB = "rgb:ff/00/00";


### PR DESCRIPTION
## Summary

ESC + a non-backslash byte mid-string now drops the held payload and re-dispatches that byte as a fresh escape (e.g. `ESC [` mid-OSC starts a CSI, not a buffered `[`), matching xterm's `sos_table` (`VTPrsTbl.c`). Pre-fix, OSC swallowed the byte and continued the string, while DCS/APC stayed in the string state until a real ST arrived — a stuck state a malformed/griefer stream could hold open indefinitely.

## Background

xterm handles ESC/ST/BEL/CAN/SUB for all string types (OSC/DCS/APC) in one place — `sos_table`. OC2R previously reimplemented the ESC/ST logic in each manager, and the three copies diverged: OSC's `lastChar` arm buffered the post-ESC byte (swallow), while DCS/APC's set `lastChar` and never returned to ground (stuck). This centralizes termination in one path, mirroring xterm's single table.

## Changes

- **`TerminalOutput.handleStringByte`** (new) owns termination uniformly for all three string states. An ESC seen mid-string arms a `stringEscapePending` flag resolved by the next byte:
  - `\` → completes ST (terminate + process payload)
  - `BEL` → OSC: terminate + process (`CASE_BELL`, charproc.c:3687); DCS/APC: ring + hold (charproc.c:3697)
  - `CAN`/`SUB` → abort to ground (`CASE_CAN`/`CASE_SUB`); direct abort, no re-dispatch (CAN/SUB are cancel bytes, not escape introducers)
  - other → drop the held payload and re-dispatch as a fresh escape (`ESC [` → CSI)
  - `ESC ESC` → re-arm with the string held (xterm re-enters `esc_table`), so `ESC ESC \` completes ST and `ESC ESC [` drops it
- **`StringSequenceHandler`** (new interface) — `accumulate`/`terminate`/`abort`/`reset`; the managers implement it and own only their type-specific buffering.
- **`OSCManager`/`DCSManager`/`APCManager`** — ESC/BEL/`lastChar` logic removed (moved up to `handleStringByte`); DCS/APC are clean stubs (no-arg constructors) pending future sixel/ReGIS support.
- **`EscapeLiterals`** (new, test) — shared `ESC`/`CSI`/`OSC`/`DCS`/`APC`/`ST`/`BEL`/`CAN`/`SUB`/`BACKSLASH`. Adopted by `TerminalBufferTest` (removes 5 private copies).

## Behavior changes

- The stuck-DCS/APC griefer vector is closed: every ESC-interleaved variant returns to ground. (A pure no-ESC garbage stream still parks in DCS — xterm-identical, parity says fine.)
- `CAN`/`SUB` mid-string now abort to ground (previously OSC buffered them as payload).
- `BEL` in DCS/APC now rings (previously silently swallowed); `BEL` in OSC still terminates (unchanged).

## Divergences from xterm (intentional, documented in code)

- **C0 controls mid-string** (`ESC BS`/`CR`/`LF`/`TAB`/`SO`/`SI`): xterm executes the control and holds the string (`CASE_BS`/`TAB`/`VMOT`/`CR`/`SO`/`SI`); OC2R aborts-and-redispatches. A control interleaved into an OSC payload is malformed; dropping it is the stricter, griefer-safe direction and can't be abused.
- **Nested string start** (`ESC P`/`ESC ]` mid-string): xterm's `BeginString` appends to the old payload; OC2R aborts-and-starts-fresh (saner — no cross-contamination of payloads).

## Tests

17 new `StringSequenceTest` cases, revert-and-fail proven (reverting the parser files to base: 12/17 fail, including both ESC-BEL regression cases; the 5 regression cases pass on both). Full gate: 301 tests / 0 failures, PMD 0, Checkstyle 0, SpotBugs 0.

Assisted by: GLM (syn:large:text on synthetic.new) — code generation and review.
