### PR TITLE
feat: implement DECSTR soft terminal reset (CSI ! p)

### DIFF
--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH5.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH5.java
@@ -1,6 +1,7 @@
 package li.cil.oc2.common.vm.terminal.escapes.csi;
 
 import li.cil.oc2.common.vm.terminal.Terminal;
+import li.cil.oc2.common.vm.terminal.escapes.index.DECSTR;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -18,7 +19,7 @@ public class CH5
         if (state.greaterThan) { // XTSMPOINTER
             LOGGER.warn("XTSMPOINTER not implemented");
         } else if (state.exclamation) { // DECSTR
-            LOGGER.warn("DECSTR not implemented");
+            DECSTR.execute(terminal);
         } else if (state.quote) { // DECSCL
             LOGGER.warn("DECSCL not implemented");
         } else if (state.dollarSign) { // DECRQM

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/index/DECSTR.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/index/DECSTR.java
@@ -1,0 +1,54 @@
+package li.cil.oc2.common.vm.terminal.escapes.index;
+
+import li.cil.oc2.common.vm.terminal.Terminal;
+import li.cil.oc2.common.vm.terminal.color.TerminalColors;
+import li.cil.oc2.common.vm.terminal.escapes.SavedCursor;
+import li.cil.oc2.common.vm.terminal.modes.ModeState;
+import li.cil.oc2.common.vm.terminal.modes.PrivateModeState;
+
+/**
+ * Soft Terminal Reset (DECSTR, {@code CSI ! p}) — the gentler counterpart to {@link RIS}. Resets
+ * rendition, mode tables, parser state, charsets, scroll margins, and the saved cursor to power-on
+ * defaults WITHOUT the destructive geometry reset RIS performs.
+ *
+ * <p>Per DEC VT510-RM Table 5-9 and xterm-410 {@code VTReset(full=false)} (charproc.c,
+ * {@code CASE_DECSTR}): DECSTR resets DECSTBM (margins to full page), DECOM (to absolute), DECAWM
+ * (to default), IRM (to replace), DECTCEM (to visible), charsets (to ASCII), SGR rendition
+ * (colors+style, not the OSC 4 palette), DECSCA, and the saved-cursor position (to home). It does
+ * not clear the screen, reset tab stops, move the active cursor, change column width, drop the
+ * input queue, or reset the OSC 4 palette — all of which RIS does.
+ *
+ * <p>Mirrors {@link RIS}: a static reset command in {@code escapes.index} rather than a
+ * {@link Terminal} method, so it writes Terminal's public fields from outside (as RIS does). Writing
+ * them from inside Terminal would trip SpotBugs {@code PA_PUBLIC_PRIMITIVE_ATTRIBUTE} ("public field
+ * set from inside the class"), which RIS avoids precisely by living here.
+ *
+ * <p>DECAWM: VT510-RM Table 5-9 lists DECAWM off, but xterm restores it to the resource default
+ * (on); OC2R's {@link PrivateModeState} default is DECAWM=true (matching xterm), so a fresh
+ * {@code PrivateModeState} matches xterm. (OC2R todo.md's claim that DECSTR preserves scroll
+ * margins is incorrect — DEC and xterm both reset DECSTBM to full.)
+ *
+ * <p>Column-width invariant: DECSTR preserves width, so the fresh {@code PrivateModeState} (which
+ * clears DECCOLM) re-applies {@code DECCOLM = (width == 132)} to keep the flag and the allocated
+ * width in agreement — the same invariant RIS documents.
+ */
+public class DECSTR {
+    public static void execute(final Terminal terminal) {
+        terminal.resetRendition();
+        final int preservedWidth = terminal.width;
+        terminal.currentModeState = new ModeState();
+        terminal.currentPrivateModeState = new PrivateModeState();
+        // DECSTR preserves column width (unlike RIS), so re-apply DECCOLM to keep the flag and
+        // the allocated width in agreement — the same invariant RIS documents.
+        terminal.currentPrivateModeState.DECCOLM = (preservedWidth == 132);
+        terminal.savePrivateModeState = new PrivateModeState();
+        terminal.state = Terminal.State.NORMAL;
+        // DECSTBM: scroll margins to full page. DEC VT510-RM Table 5-9 and xterm both reset this
+        terminal.scrollFirst = 0;
+        terminal.scrollLast = Terminal.HEIGHT - 1;
+        terminal.drawingModeG0 = TerminalColors.DrawingMode.ASCII;
+        terminal.drawingModeG1 = TerminalColors.DrawingMode.ASCII;
+        terminal.useG0 = true;
+        SavedCursor.reset(terminal); // DECSC saved cursor to home + default rendition
+    }
+}

--- a/src/test/java/li/cil/oc2/common/vm/terminal/DecstrTest.java
+++ b/src/test/java/li/cil/oc2/common/vm/terminal/DecstrTest.java
@@ -1,0 +1,208 @@
+package li.cil.oc2.common.vm.terminal;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import li.cil.oc2.common.vm.terminal.color.TerminalColors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static li.cil.oc2.common.vm.terminal.EscapeLiterals.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * DECSTR (Soft Terminal Reset, {@code CSI ! p}) integration tests.
+ *
+ * <p>Feeds real escape sequences through the {@link Terminal} parser (the same path the VM firmware
+ * uses) via {@code putOutput}, then asserts on terminal state. DECSTR is the gentler counterpart to
+ * RIS: it resets mode tables, rendition, charsets, scroll margins, and the saved cursor to defaults
+ * WITHOUT clearing the screen, resetting tab stops, moving the cursor, changing column width,
+ * dropping the input queue, or resetting the OSC 4 palette. Semantics verified against DEC
+ * VT510-RM Table 5-9 and xterm-410 {@code VTReset(full=false)}.
+ *
+ * <p>Split out of {@link TerminalBufferTest} so the soft-reset feature has a dedicated home, mirroring
+ * the {@code SGRTest} precedent. The RIS-contract tests it is contrasted against live in
+ * {@code TerminalBufferTest} ({@code risResets*}, {@code risClearsInput}).
+ */
+public class DecstrTest {
+    private static final String DECSTR = CSI + "!p";
+    private static final String RED_RGB = "rgb:ff/00/00";
+    private static final String OSC4_SET_16_RED = OSC + "4;16;" + RED_RGB + BEL;
+
+    private Terminal terminal;
+
+    @BeforeEach
+    void setUp() {
+        terminal = new Terminal();
+    }
+
+    @Test
+    void decstrPreservesScreenContentsAndCursor() {
+        // Revert-and-fail: RIS clears the screen and homes the cursor; DECSTR preserves both.
+        write(terminal, "Hello");
+        write(terminal, CSI + "3;5H"); // cursor to row 3, col 5 -> x=4, y=2
+        assertEquals('H', charAt(0, 0), "precondition: content written at (0,0)");
+        assertEquals(4, terminal.x, "precondition: cursor x");
+        assertEquals(2, terminal.y, "precondition: cursor y");
+
+        write(terminal, DECSTR);
+
+        assertEquals('H', charAt(0, 0), "DECSTR preserves screen contents");
+        assertEquals(4, terminal.x, "DECSTR preserves the active cursor x");
+        assertEquals(2, terminal.y, "DECSTR preserves the active cursor y");
+    }
+
+    @Test
+    void decstrResetsSgrRenditionButPreservesOsc4Palette() {
+        // Revert-and-fail: RIS resets the OSC 4 palette too; DECSTR resets only SGR rendition.
+        write(terminal, OSC4_SET_16_RED);  // palette256[16] = red (OSC 4)
+        write(terminal, CSI + "1;31m");    // bold + red foreground (SGR)
+        assertEquals(0xff0000, terminal.palette256[16], "precondition: OSC 4 set entry 16 to red");
+        assertNotEquals(TerminalColors.getDefaultPalette256()[16], terminal.palette256[16],
+            "precondition: entry 16 differs from the default");
+        assertEquals(Terminal.STYLE_BOLD_MASK, terminal.style, "precondition: bold");
+
+        write(terminal, DECSTR);
+
+        assertEquals(TerminalColors.DEFAULT_STYLE, terminal.style, "DECSTR resets SGR style to default");
+        assertEquals(TerminalColors.ColorMode.DEFAULT_FOREGROUND, terminal.currentForegroundColorMode,
+            "DECSTR resets the foreground color mode to default");
+        assertEquals(0xff0000, terminal.palette256[16], "DECSTR preserves the OSC 4 palette (entry 16)");
+        assertNotEquals(TerminalColors.getDefaultPalette256()[16], terminal.palette256[16],
+            "DECSTR does not reset the OSC 4 palette to default");
+    }
+
+    @Test
+    void decstrResetsOriginInsertAndAutowrapModes() {
+        write(terminal, CSI + "?6h"); // DECOM on (origin mode)
+        write(terminal, CSI + "?7l"); // DECAWM off (autowrap)
+        write(terminal, CSI + "4h");  // IRM on (insert mode)
+        assertTrue(terminal.currentPrivateModeState.DECOM, "precondition: DECOM on");
+        assertFalse(terminal.currentPrivateModeState.DECAWM, "precondition: DECAWM off");
+        assertTrue(terminal.currentModeState.IRM, "precondition: IRM on");
+
+        write(terminal, DECSTR);
+
+        assertFalse(terminal.currentPrivateModeState.DECOM, "DECSTR resets DECOM to absolute");
+        assertTrue(terminal.currentPrivateModeState.DECAWM, "DECSTR resets DECAWM to default (on)");
+        assertFalse(terminal.currentModeState.IRM, "DECSTR resets IRM to replace");
+    }
+
+    @Test
+    void decstrResetsScrollMarginsToFull() {
+        // Corrects OC2R todo.md, which claims DECSTR preserves scroll margins: DEC VT510-RM
+        // Table 5-9 and xterm-410 both reset DECSTBM to the full page.
+        write(terminal, CSI + "5;10r"); // DECSTBM: top margin 5, bottom margin 10
+        assertEquals(4, terminal.scrollFirst, "precondition: top margin");
+        assertEquals(9, terminal.scrollLast, "precondition: bottom margin");
+
+        write(terminal, DECSTR);
+
+        assertEquals(0, terminal.scrollFirst, "DECSTR resets the top margin to 0");
+        assertEquals(Terminal.HEIGHT - 1, terminal.scrollLast, "DECSTR resets the bottom margin to full page");
+    }
+
+    @Test
+    void decstrResetsCharsets() {
+        write(terminal, ESC + "(0"); // designate G0 = DEC special graphics
+        assertEquals(TerminalColors.DrawingMode.SPECIAL_GRAPHICS, terminal.drawingModeG0,
+            "precondition: G0 is special graphics");
+
+        write(terminal, DECSTR);
+
+        assertEquals(TerminalColors.DrawingMode.ASCII, terminal.drawingModeG0, "DECSTR resets G0 to ASCII");
+        assertEquals(TerminalColors.DrawingMode.ASCII, terminal.drawingModeG1, "DECSTR resets G1 to ASCII");
+        assertTrue(terminal.useG0, "DECSTR resets useG0 to true");
+    }
+
+    @Test
+    void decstrResetsSavedCursorToHome() {
+        write(terminal, CSI + "5;5H"); // cursor to (4,4)
+        write(terminal, CSI + "1m");   // bold
+        write(terminal, ESC + "7");    // DECSC: save cursor + rendition
+        assertEquals(4, terminal.savedX, "precondition: saved cursor x");
+        assertEquals(4, terminal.savedY, "precondition: saved cursor y");
+        assertEquals(Terminal.STYLE_BOLD_MASK, terminal.savedStyle, "precondition: saved bold style");
+
+        write(terminal, DECSTR);
+
+        assertEquals(0, terminal.savedX, "DECSTR resets the saved cursor x to home");
+        assertEquals(0, terminal.savedY, "DECSTR resets the saved cursor y to home");
+        assertEquals(TerminalColors.DEFAULT_STYLE, terminal.savedStyle, "DECSTR resets the saved rendition to default");
+    }
+
+    @Test
+    void decstrPreservesTabStops() {
+        // Revert-and-fail: RIS rebuilds default tab stops (every TAB_WIDTH); DECSTR preserves
+        // user-set stops. Column 3 is not a default tab position, so a stop there is unambiguous.
+        write(terminal, CSI + "4G"); // CHA: cursor to column 4 (x=3)
+        write(terminal, ESC + "H");  // HTS: set a tab stop at the cursor column
+        assertTrue(terminal.tabs[3], "precondition: custom tab stop at column 3");
+
+        write(terminal, DECSTR);
+
+        assertTrue(terminal.tabs[3], "DECSTR preserves user-set tab stops");
+    }
+
+    @Test
+    void decstrPreservesColumnWidthAndDeccolmFlag() {
+        // The width/DECCOLM invariant: DECSTR must preserve width AND keep the DECCOLM flag in
+        // agreement with it. Revert-and-fail: a soft reset that took a fresh PrivateModeState
+        // without re-applying DECCOLM would leave the flag false while width stayed 132.
+        write(terminal, CSI + "?3h"); // DECCOLM on -> 132 columns (destructive, like RIS)
+        assertEquals(132, terminal.getTerminalWidth(), "precondition: 132 columns");
+        assertTrue(terminal.currentPrivateModeState.DECCOLM, "precondition: DECCOLM flag set");
+
+        write(terminal, DECSTR);
+
+        assertEquals(132, terminal.getTerminalWidth(), "DECSTR preserves column width");
+        assertTrue(terminal.currentPrivateModeState.DECCOLM,
+            "DECSTR preserves the DECCOLM flag in agreement with the preserved width");
+    }
+
+    @Test
+    void decstrPreservesInputQueue() {
+        // Revert-and-fail: RIS clears the input queue; DECSTR preserves it.
+        terminal.io.putInput((byte) 'A');
+        terminal.io.putInput((byte) 'B');
+
+        write(terminal, DECSTR);
+
+        assertNotEquals(-1, terminal.io.readInput(), "DECSTR preserves the input queue (A)");
+        assertNotEquals(-1, terminal.io.readInput(), "DECSTR preserves the input queue (B)");
+        assertEquals(-1, terminal.io.readInput(), "input queue is drained after the two bytes");
+    }
+
+    @Test
+    void decstrResetsSavedPrivateModeState() {
+        write(terminal, CSI + "?7l"); // DECAWM off
+        write(terminal, CSI + "?6h"); // DECOM on
+        write(terminal, CSI + "?7s"); // XTSAVE mode 7 (DECAWM)
+        write(terminal, CSI + "?6s"); // XTSAVE mode 6 (DECOM)
+        assertFalse(terminal.savePrivateModeState.DECAWM, "precondition: DECAWM saved as off");
+        assertTrue(terminal.savePrivateModeState.DECOM, "precondition: DECOM saved as on");
+
+        write(terminal, DECSTR);
+
+        assertTrue(terminal.savePrivateModeState.DECAWM, "DECSTR resets saved DECAWM to default (on)");
+        assertFalse(terminal.savePrivateModeState.DECOM, "DECSTR resets saved DECOM to default (off)");
+    }
+
+    @Test
+    void decstrResetsParserStateToNormal() {
+        write(terminal, CSI + "3"); // partial CSI leaves the parser in CONTROL_SEQUENCE
+        assertEquals(Terminal.State.CONTROL_SEQUENCE, terminal.state, "precondition: parser mid-sequence");
+
+        write(terminal, DECSTR);
+
+        assertEquals(Terminal.State.NORMAL, terminal.state, "DECSTR returns the parser to NORMAL");
+    }
+
+    private void write(final Terminal target, final String text) {
+        target.io.putOutput(ByteBuffer.wrap(text.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    private char charAt(final int x, final int y) {
+        final int row = y + terminal.lastRowToDisplayMax - Terminal.HEIGHT;
+        return (char) terminal.buffer[x + row * terminal.width];
+    }
+}

--- a/todo.md
+++ b/todo.md
@@ -719,7 +719,7 @@ Follow-up'ы из ревью `pr/screen-features` (PR #10). Мелкие, изо
 
 - [ ] **DECSLRM + DECSTR** (средний)
   - `DECSLRM` (left/right margins, `CSI Pl;Pr s` — в `CH6.java:24` стоит `LOGGER.warn("DECSLRM not implemented")`) — нужен tmux / вертикальные сплиты vim. Пересечение с `DECOM` и `DECLRMM`/`DECRLM`.
-  - `DECSTR` (soft reset, `CSI ! p` — `CH5.java:21` warn) — сброс таблиц режимов без полного RIS (курсор/тэбы/скролл-маргины сохраняются).
+  - `DECSTR` (soft reset, `CSI ! p`) — **сделано** (`escapes/index/DECSTR.java`, тесты `DecstrTest`): сброс таблиц режимов без полного RIS. Курсор и тэбы сохраняются; скролл-маргины сбрасываются в полный экран (DEC VT510-RM Table 5-9 + xterm-410 `VTReset(full=false)` — прежняя заметка «маргины сохраняются» была неверной).
 
 ## 36. Аудит VT100-терминала №2 — 6 суб-агентов (2026-08-23, ветка 1.21.1)
 


### PR DESCRIPTION
Implements DECSTR (Soft Terminal Reset, `CSI ! p`) — the gentler counterpart to RIS. Previously a `LOGGER.warn("DECSTR not implemented")` stub at `CH5.java:21`.

## What it does

Resets mode tables, rendition, parser state, charsets, scroll margins, and the saved cursor to power-on defaults — **without** the destructive geometry reset RIS performs. No screen clear, no tab-stop rebuild, no cursor home, no width change, no input-queue drop, no OSC 4 palette reset.

Semantics verified against DEC VT510-RM Table 5-9 and xterm-410 `VTReset(full=false)` (`charproc.c`, `CASE_DECSTR`):

| Resets | Preserves |
|---|---|
| DECSTBM (margins → full page) | Screen contents |
| DECOM (→ absolute) | Tab stops |
| DECAWM (→ default) | Column width / DECCOLM flag |
| IRM (→ replace) | Active cursor position |
| Charsets G0/G1 (→ ASCII) | Scrollback |
| SGR rendition (colors + style) | OSC 4 palette (`palette256`) |
| Saved cursor (→ home) | Input queue |

## Implementation

- New `escapes/index/DECSTR.java` — a static `execute(Terminal)`, sibling to `RIS.java`. Lives in `escapes.index` (not as a `Terminal` method) so it writes Terminal's public fields from outside, the same placement that keeps RIS clear of SpotBugs `PA_PUBLIC_PRIMITIVE_ATTRIBUTE` ("public field set from inside the class").
- `CH5.java`: the `!p` branch calls `DECSTR.execute(terminal)` instead of logging.
- `Terminal.java` and `RIS.java` untouched.

### Column-width invariant

DECSTR preserves width (unlike RIS), so after the fresh `PrivateModeState` (which clears DECCOLM) it re-applies `DECCOLM = (width == 132)` to keep the flag and the allocated width in agreement — the same invariant RIS documents.

### DECAWM

VT510-RM Table 5-9 lists DECAWM off after DECSTR; xterm restores it to the resource default (on). This implementation follows xterm — OC2R's `PrivateModeState` default is `DECAWM=true`, so a fresh `PrivateModeState` matches. Strict-DEC off would make DECSTR appear to break autowrap.

### Note on `todo.md` §35

The existing note claimed DECSTR preserves scroll margins — incorrect. DEC VT510-RM Table 5-9 and xterm-410 both reset DECSTBM to the full page. Corrected in-place in `todo.md` (marked done, margin behavior corrected with the spec citation).

## Verification

- `./gradlew check` — BUILD SUCCESSFUL (test, checkstyle, pmd, spotbugs, lintRatchet all green; zero baseline changes, zero suppressions).
- New `DecstrTest` — 11 tests, revert-and-fail. The load-bearing test is `decstrPreservesColumnWidthAndDeccolmFlag`: at 132 cols, DECSTR must preserve `width == 132` **and** keep `DECCOLM == true` (a soft reset that took a fresh `PrivateModeState` without re-applying DECCOLM would leave the flag false while width stayed 132).
- Rebased onto `upstream/work` @ `f197ec25` (clean, no conflicts).

Assisted by: GLM (syn:large:text on synthetic.new) — code generation and review.