### PR TITLE
feat: DECSCPP non-destructive column change + resizeWidth primitive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning: [S
 
 ### Added
 
+- **Terminal**: non-destructive column change — DECSCPP (`CSI Pn $ |`) selects 80 or 132 columns via a new `resizeWidth` primitive that copies existing contents into the surviving columns instead of clearing: screen content, scroll margins, cursor position and tab stops are preserved (new columns are default-initialized, matching xterm's resize). Private-marker forms (`?`/`>` prefix) are ignored, as xterm does. DECCOLM (mode 3) remains the destructive reset (#38)
 - **Terminal**: per-instance color palette — OSC 4 (query/set an indexed color) and OSC 104 (reset one or all indexed colors to default) are implemented; "computed dim" derives SGR 2 (dim) from the palette instead of a fixed table (#31)
 - **Terminal**: CSI cursor-positioning coverage completed — CBT/CHT (backward/forward tabulation), CNL/CPL (cursor down/up + CR), VPR/HPA/HPR (vertical/horizontal position, absolute/relative), RCP and CSI ?u (XTRESTORE, save/restore private mode state), REP (repeat preceding char) (#24)
 - **Terminal**: `XT_RAW_PASSTHROUGH` mode (CSI ?7777h/l) — an in-band byte-capture debugger that renders every received byte as a visible glyph without interpreting it, for diagnosing what a guest program actually sends

--- a/config/spotbugs/baseline.xml
+++ b/config/spotbugs/baseline.xml
@@ -32936,4 +32936,28 @@
   </BugInstance>
   
   
+<BugInstance type="AT_STALE_THREAD_WRITE_OF_PRIMITIVE" priority="2" rank="14" abbrev="AT" category="MT_CORRECTNESS" instanceHash="4fd3b65bf2a020e7b9d161a00d1b569c" instanceOccurrenceNum="0" instanceOccurrenceMax="0" cweid="413">
+    <ShortMessage>This write of this shared primitive variable may not be visible to other threads</ShortMessage>
+    <LongMessage>Shared primitive variable "width" in one thread may not yield the value of the most recent write from another thread</LongMessage>
+    <Class classname="li.cil.oc2.common.vm.terminal.Terminal" primary="true" classAnnotationNames="li.cil.ceres.api.Serialized">
+      <SourceLine classname="li.cil.oc2.common.vm.terminal.Terminal" start="39" end="557" sourcefile="Terminal.java" sourcepath="li/cil/oc2/common/vm/terminal/Terminal.java" relSourcepath="java/li/cil/oc2/common/vm/terminal/Terminal.java">
+        <Message>At Terminal.java:[lines 39-557]</Message>
+      </SourceLine>
+      <Message>In class li.cil.oc2.common.vm.terminal.Terminal</Message>
+    </Class>
+    <Method classname="li.cil.oc2.common.vm.terminal.Terminal" name="resizeWidth" signature="(I)V" isStatic="false" primary="true">
+      <SourceLine classname="li.cil.oc2.common.vm.terminal.Terminal" start="302" end="387" startBytecode="0" endBytecode="1135" sourcefile="Terminal.java" sourcepath="li/cil/oc2/common/vm/terminal/Terminal.java" relSourcepath="java/li/cil/oc2/common/vm/terminal/Terminal.java" />
+      <Message>In method li.cil.oc2.common.vm.terminal.Terminal.resizeWidth(int)</Message>
+    </Method>
+    <Field classname="li.cil.oc2.common.vm.terminal.Terminal" name="width" signature="I" isStatic="false" primary="true">
+      <SourceLine classname="li.cil.oc2.common.vm.terminal.Terminal" sourcefile="Terminal.java" sourcepath="li/cil/oc2/common/vm/terminal/Terminal.java" relSourcepath="java/li/cil/oc2/common/vm/terminal/Terminal.java">
+        <Message>In Terminal.java</Message>
+      </SourceLine>
+      <Message>Field li.cil.oc2.common.vm.terminal.Terminal.width</Message>
+    </Field>
+    <SourceLine classname="li.cil.oc2.common.vm.terminal.Terminal" primary="true" start="306" end="306" startBytecode="21" endBytecode="21" sourcefile="Terminal.java" sourcepath="li/cil/oc2/common/vm/terminal/Terminal.java" relSourcepath="java/li/cil/oc2/common/vm/terminal/Terminal.java">
+      <Message>At Terminal.java:[line 306]</Message>
+    </SourceLine>
+  </BugInstance>
+  
 </BugCollection>

--- a/src/main/java/li/cil/oc2/common/vm/terminal/Terminal.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/Terminal.java
@@ -201,6 +201,22 @@ public class Terminal {
         style = TerminalColors.DEFAULT_STYLE;
     }
 
+    /**
+     * Resolve the erase background color from the current SGR background mode — the VT510 erase
+     * character, used by {@link #setWidth} (DECCOLM's destructive clear) and matching the same
+     * resolution in {@link TerminalBuffer#clear}. (DECSCPP's {@link #resizeWidth} does NOT use
+     * this — it default-initializes new columns, since a resize is not a clear.)
+     */
+    private ColorData resolveEraseBackground() {
+        return switch (currentBackgroundColorMode) {
+            case SIXTEEN_COLOR -> sixteenColor;
+            case TWO_FIFTY_SIX_COLOR -> twoFiftySixColor;
+            case TRUE_COLOR -> backgroundColor;
+            case SIXTEEN_COLOR_BRIGHT -> sixteenColorBright;
+            default -> TerminalColors.DEFAULT_BACKGROUND_COLOR;
+        };
+    }
+
     public int getTerminalWidth() {
         return width;
     }
@@ -216,13 +232,7 @@ public class Terminal {
         // Erase color: DECCOLM clears with the current SGR background (VT510 erase
         // character), matching bufferManager.clear(). RIS resets the modes before
         // calling setWidth, so it still fills with defaults.
-        final ColorData background = switch (currentBackgroundColorMode) {
-            case SIXTEEN_COLOR -> sixteenColor;
-            case TWO_FIFTY_SIX_COLOR -> twoFiftySixColor;
-            case TRUE_COLOR -> backgroundColor;
-            case SIXTEEN_COLOR_BRIGHT -> sixteenColorBright;
-            default -> TerminalColors.DEFAULT_BACKGROUND_COLOR;
-        };
+        final ColorData background = resolveEraseBackground();
 
         // Reallocate main buffer arrays
         final int mainSize = newWidth * HEIGHT * SCROLL_BACK_COUNT;
@@ -264,6 +274,127 @@ public class Terminal {
         this.setCursorPos(0, 0);
 
         // Mark all rows dirty
+        this.renderers.forEach(model -> model.getDirtyMask().set(-1));
+    }
+
+    /**
+     * Non-destructive width change (DECSCPP, {@code CSI Pn $ |}): reallocates the width-dependent
+     * buffers at the new column count while COPYING existing contents into the surviving columns,
+     * instead of clearing them as {@link #setWidth} does. Per DEC VT510-RM and xterm-410
+     * {@code CASE_DECSCPP}: DECSCPP does not clear page memory, reset scrolling regions, reset
+     * SGR, or reset tab stops — it only changes the column count, clamping the cursor if it now
+     * sits beyond the new width. Columns beyond the new width are lost (132→80); new columns
+     * (80→132) are default-initialized (blank, default fg/bg, no style) — a resize, not a clear,
+     * so unlike {@link #setWidth} (DECCOLM's destructive clear, which fills with the current SGR
+     * erase background) the new cells get defaults, matching xterm's {@code calloc}-zero on
+     * {@code Reallocate}.
+     *
+     * <p>The caller (CH13) sets the DECCOLM flag to match — this method is flag-agnostic so it
+     * can be reused by a future DECNCSM-gated non-destructive DECCOLM path.
+     *
+     * <p>Layout: the buffers are flat row-major with {@code width} as the stride (no circular
+     * pointer — {@code lastRowToDisplay(Max)} are row-count windows, width-independent), so each
+     * row is copied with a stride-aware {@link System#arraycopy}. The shared default object used
+     * to fill new columns is safe because the write path ({@code TerminalBufferWriter.putChar})
+     * REPLACES the {@code colors[idx]} reference rather than mutating it in place — the same
+     * property {@link #setWidth} already relies on.
+     */
+    public void resizeWidth(final int newWidth) {
+        // Guard: degenerate widths would break Math.clamp; a no-op resize avoids a pointless
+        // reallocation (DECSCPP to the current width does nothing).
+        if (newWidth < 1 || newWidth == this.width) {
+            return;
+        }
+        final int oldWidth = this.width;
+        this.width = newWidth;
+        final int copyCols = Math.min(oldWidth, newWidth);
+
+        // New columns are default-initialized (blank, default fg/bg, no style) — DECSCPP is a
+        // resize, not a clear, so the new cells get defaults rather than the current SGR erase
+        // background that setWidth (DECCOLM's destructive clear) uses. Matches xterm's calloc-
+        // zero on Reallocate. Surviving columns keep their actual colors via the arraycopy below.
+        final ColorData defaultBackground = TerminalColors.DEFAULT_BACKGROUND_COLOR.copy();
+
+        // Main buffer (incl. scrollback): reallocate at the new stride, fill with defaults, then
+        // copy the surviving columns of every row. mainRows is width-independent, so the row
+        // count and the lastRowToDisplay(Max) window are preserved as-is.
+        final int mainRows = HEIGHT * SCROLL_BACK_COUNT;
+        final int[] newBuffer = new int[newWidth * mainRows];
+        final ColorData[] newColors = new ColorData[newWidth * mainRows];
+        final ColorData[] newColorsBackground = new ColorData[newWidth * mainRows];
+        final byte[] newStyles = new byte[newWidth * mainRows];
+        Arrays.fill(newBuffer, ' ');
+        Arrays.fill(newColors, TerminalColors.DEFAULT_FOREGROUND_COLOR.copy());
+        Arrays.fill(newColorsBackground, defaultBackground);
+        Arrays.fill(newStyles, TerminalColors.DEFAULT_STYLE);
+        for (int r = 0; r < mainRows; r++) {
+            final int src = r * oldWidth;
+            final int dst = r * newWidth;
+            System.arraycopy(this.buffer, src, newBuffer, dst, copyCols);
+            System.arraycopy(this.colors, src, newColors, dst, copyCols);
+            System.arraycopy(this.colorsBackground, src, newColorsBackground, dst, copyCols);
+            System.arraycopy(this.styles, src, newStyles, dst, copyCols);
+        }
+        this.buffer = newBuffer;
+        this.colors = newColors;
+        this.colorsBackground = newColorsBackground;
+        this.styles = newStyles;
+
+        // Alt buffer (no scrollback): same per-row copy.
+        final ColorData[] newAltColors = new ColorData[newWidth * HEIGHT];
+        final ColorData[] newAltColorsBackground = new ColorData[newWidth * HEIGHT];
+        final int[] newAltBuffer = new int[newWidth * HEIGHT];
+        final byte[] newAltStyles = new byte[newWidth * HEIGHT];
+        Arrays.fill(newAltBuffer, ' ');
+        Arrays.fill(newAltColors, TerminalColors.DEFAULT_FOREGROUND_COLOR.copy());
+        Arrays.fill(newAltColorsBackground, defaultBackground);
+        Arrays.fill(newAltStyles, TerminalColors.DEFAULT_STYLE);
+        for (int r = 0; r < HEIGHT; r++) {
+            final int src = r * oldWidth;
+            final int dst = r * newWidth;
+            System.arraycopy(this.altBuffer, src, newAltBuffer, dst, copyCols);
+            System.arraycopy(this.altColors, src, newAltColors, dst, copyCols);
+            System.arraycopy(this.altColorsBackground, src, newAltColorsBackground, dst, copyCols);
+            System.arraycopy(this.altStyles, src, newAltStyles, dst, copyCols);
+        }
+        this.altBuffer = newAltBuffer;
+        this.altColors = newAltColors;
+        this.altColorsBackground = newAltColorsBackground;
+        this.altStyles = newAltStyles;
+
+        // Tab stops: preserve existing stops in the surviving columns, default-fill new columns.
+        final boolean[] newTabs = new boolean[newWidth];
+        final boolean[] newAltTabs = new boolean[newWidth];
+        for (int i = 1; i < newWidth; i++) {
+            if (i < oldWidth) {
+                newTabs[i] = this.tabs[i];
+                newAltTabs[i] = this.altTabs[i];
+            } else if (i % TerminalColors.TAB_WIDTH == 0) {
+                newTabs[i] = true;
+                newAltTabs[i] = true;
+            }
+        }
+        this.tabs = newTabs;
+        this.altTabs = newAltTabs;
+
+        // Scroll margins + scrollback window are row-based (width-independent) — preserved per
+        // DECSCPP (does not reset DECSTBM). The active cursor is clamped only if it now sits
+        // beyond the new width (xterm CursorSet on cur_col + 1 > value); setCursorPos clamps x
+        // and clears the pending wrap + REP last-char, matching any cursor repositioning. The
+        // saved cursor is left as-is — restore routes through the clamping setCursorPos (§36 Б6).
+        if (this.x >= newWidth) {
+            setCursorPos(newWidth - 1, this.y);
+        }
+
+        // Mark all rows dirty — BOTH sinks. The renderer mask drives local redraw; markAllDirty
+        // drives the network diff. The network mark is load-bearing (Kimi gate, PR-2 review):
+        // DECSCPP is the first width path where the server PRESERVES content while the client's
+        // TerminalDiff.apply responds to the width change with a destructive setWidth — so the
+        // snapshot must re-ship the visible window or the client blanks (screen + scrollback)
+        // while the server keeps everything, diverging until the next captureFull. setWidth
+        // (DECCOLM) gets away without it only because DECCOLM's escape paths (CH2/CH3) call
+        // markAllDirty themselves — the clear ships symmetrically.
+        markAllDirty();
         this.renderers.forEach(model -> model.getDirtyMask().set(-1));
     }
 

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH13.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CH13.java
@@ -1,0 +1,55 @@
+package li.cil.oc2.common.vm.terminal.escapes.csi;
+
+import li.cil.oc2.common.vm.terminal.Terminal;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class CH13
+        extends CSISequenceHandler { // Combined Handler 13 (DECSCPP and DECSLPP/DECSNLS) — the '|'
+    // final is shared by the column-count selector ($ |) and the line-count selector (* |),
+    // branched on the intermediate byte.
+    private static final Logger LOGGER = LogManager.getLogger();
+
+    public CH13(final Terminal terminal) {
+        super(terminal);
+    }
+
+    @Override
+    public int[] defaultParameters(final CSIState state) {
+        // DECSCPP: Ps omitted (or 0) defaults to 80 columns. CSIManager substitutes this before
+        // execute, so a bare "CSI $ |" selects 80 columns (per DEC VT510-RM / xterm-410
+        // CASE_DECSCPP: default, 0, and 80 all mean 80; 132 means 132; anything else is ignored).
+        return new int[] {Terminal.WIDTH};
+    }
+
+    @Override
+    public void execute(final int[] args, final int argsCount, final CSIState state) {
+        // xterm-410 routes the private-marker forms elsewhere: csi_dec_dollar_table (the
+        // "CSI ? Pn $" table, VTPrsTbl.c:4374) maps '|' to CASE_GROUND_STATE — ignored — and
+        // only the plain csi_dollar_table (VTPrsTbl.c:3074) maps '|' to CASE_DECSCPP; the
+        // "> Pn $" form has no DECSCPP mapping either. Ignoring the prefixed forms (silently,
+        // as xterm does) keeps us from being more permissive than the reference: a mangled or
+        // probing sequence must not resize the terminal.
+        if (state.questionMark || state.greaterThan) {
+            return;
+        }
+        if (state.dollarSign) { // DECSCPP — Select Columns Per Page (CSI Pn $ |)
+            final int cols = args[0];
+            if (cols == Terminal.WIDTH) {
+                terminal.resizeWidth(Terminal.WIDTH);
+                terminal.currentPrivateModeState.DECCOLM = false;
+            } else if (cols == 132) {
+                terminal.resizeWidth(132);
+                terminal.currentPrivateModeState.DECCOLM = true;
+            }
+            // Any other value is ignored (xterm sets value = -1 and skips the resize).
+        } else if (state.asterisk) { // DECSLPP / DECSNLS — Set Lines Per Page (CSI Pn * |)
+            // Deferred: dynamic HEIGHT is a separate, larger axis (HEIGHT is static final and
+            // pervades buffer sizing, scrollback, the dirty BitSet, renderer rows, the network
+            // diff). 132x48 etc. is the eventual payoff. The '*' intermediate is parsed so this
+            // stub is reachable; implementation is a future session.
+            LOGGER.warn("DECSLPP not implemented");
+        }
+        // A bare "CSI |" (no intermediate) is not a defined sequence; ignore it.
+    }
+}

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CSIManager.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CSIManager.java
@@ -23,6 +23,7 @@ public class CSIManager {
     private boolean singleQuote = false;
     private boolean space = false;
     private boolean exclamation = false;
+    private boolean asterisk = false;
     private boolean hasArg = false;
 
     private final Terminal terminal;
@@ -71,6 +72,7 @@ public class CSIManager {
         sequences.put('x', new DECREQTPARM(terminal));
 
         sequences.put('@', new CH11(terminal));
+        sequences.put('|', new CH13(terminal));
     }
 
     public void handle(final char ch) {
@@ -131,7 +133,7 @@ public class CSIManager {
         executeHandler(ch);
     }
 
-    private boolean handleModifier(final char ch) { // NOPMD 10-case VT100 modifier dispatch
+    private boolean handleModifier(final char ch) { // NOPMD 11-case VT100 modifier dispatch
         switch (ch) {
             case ' ' -> {
                 space = true;
@@ -165,6 +167,10 @@ public class CSIManager {
                 exclamation = true;
                 return true;
             }
+            case '*' -> {
+                asterisk = true;
+                return true;
+            }
             case ';' -> {
                 argCount = Math.min(argCount + 1, args.length);
                 hasArg = true;
@@ -191,7 +197,8 @@ public class CSIManager {
                         quote,
                         singleQuote,
                         space,
-                        exclamation);
+                        exclamation,
+                        asterisk);
 
         if (handler != null) {
             int[] defaults = handler.defaultParameters(state);
@@ -218,6 +225,7 @@ public class CSIManager {
         singleQuote = false;
         space = false;
         exclamation = false;
+        asterisk = false;
         hasArg = false;
         argCount = 0;
         Arrays.fill(args, 0);

--- a/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CSIState.java
+++ b/src/main/java/li/cil/oc2/common/vm/terminal/escapes/csi/CSIState.java
@@ -9,6 +9,7 @@ public class CSIState {
     public boolean singleQuote;
     public boolean space;
     public boolean exclamation;
+    public boolean asterisk;
 
     public CSIState(
             boolean questionMark,
@@ -18,7 +19,8 @@ public class CSIState {
             boolean quote,
             boolean singleQuote,
             boolean space,
-            boolean exclamation) {
+            boolean exclamation,
+            boolean asterisk) {
         this.questionMark = questionMark;
         this.greaterThan = greaterThan;
         this.dollarSign = dollarSign;
@@ -27,5 +29,6 @@ public class CSIState {
         this.singleQuote = singleQuote;
         this.space = space;
         this.exclamation = exclamation;
+        this.asterisk = asterisk;
     }
 }

--- a/src/test/java/li/cil/oc2/common/vm/terminal/TerminalBufferTest.java
+++ b/src/test/java/li/cil/oc2/common/vm/terminal/TerminalBufferTest.java
@@ -1522,6 +1522,132 @@ public class TerminalBufferTest {
             "cleared cell must be a space");
     }
 
+    @Test
+    void decscppGrowsWidthPreservingContentMarginsCursorAndSgr() {
+        // Revert-and-fail: DECCOLM (?3h) clears the screen, homes the cursor, resets margins and
+        // SGR. DECSCPP (CSI 132$|) does none of that — it grows the width, preserving everything.
+        write(terminal, CSI + "41m");             // SGR: red background
+        write(terminal, SAMPLE_LINE);             // "ABCDEFGH" at row 0, cols 0-7
+        write(terminal, CSI + "5;10r");           // DECSTBM: top margin 5, bottom margin 10
+        write(terminal, CSI + "3;5H");            // cursor to row 3, col 5 (x=4, y=2)
+        // preconditions
+        assertEquals('A', charAt(0, 0), "precondition: content at (0,0)");
+        assertEquals('H', charAt(7, 0), "precondition: content at (7,0)");
+        assertEquals(4, terminal.x, "precondition: cursor x");
+        assertEquals(2, terminal.y, "precondition: cursor y");
+        assertEquals(4, terminal.scrollFirst, "precondition: top margin");
+        assertEquals(9, terminal.scrollLast, "precondition: bottom margin");
+        assertEquals(TerminalColors.ColorMode.SIXTEEN_COLOR, terminal.currentBackgroundColorMode,
+            "precondition: SGR bg set");
+
+        write(terminal, CSI + "132$|");           // DECSCPP -> 132 columns (non-destructive)
+
+        assertEquals(132, terminal.getTerminalWidth(), "DECSCPP switches to 132 columns");
+        assertEquals(132 * Terminal.HEIGHT * Terminal.SCROLL_BACK_COUNT, terminal.buffer.length,
+            "buffers reallocate to 132 columns");
+        assertEquals('A', charAt(0, 0), "DECSCPP preserves content at (0,0)");
+        assertEquals('H', charAt(7, 0), "DECSCPP preserves content at (7,0)");
+        assertEquals(4, terminal.x, "DECSCPP preserves the cursor x (no home)");
+        assertEquals(2, terminal.y, "DECSCPP preserves the cursor y (no home)");
+        assertEquals(4, terminal.scrollFirst, "DECSCPP preserves the top margin");
+        assertEquals(9, terminal.scrollLast, "DECSCPP preserves the bottom margin");
+        assertEquals(TerminalColors.ColorMode.SIXTEEN_COLOR, terminal.currentBackgroundColorMode,
+            "DECSCPP preserves SGR (no rendition reset)");
+        assertTrue(terminal.currentPrivateModeState.DECCOLM,
+            "DECSCPP sets the DECCOLM flag to match the 132-column width");
+        // New columns are default-initialized (blank, default bg) — DECSCPP is a resize, not a
+        // clear, so unlike DECCOLM (which fills with the current SGR erase background) the new
+        // cells get defaults, matching xterm's calloc-zero on Reallocate. Revert-and-fail: an
+        // erase-background fill would leave SIXTEEN_COLOR here instead of DEFAULT_BACKGROUND.
+        assertEquals(' ', charAt(80, 0), "new column 80 is blank");
+        final int newColIdx = cellIndex(80, 0);
+        assertEquals(TerminalColors.ColorMode.DEFAULT_BACKGROUND, terminal.colorsBackground[newColIdx].mode,
+            "new columns are default-initialized, not filled with the current SGR background");
+    }
+
+    @Test
+    void decscppShrinksWidthLosingColumnsAndClampingCursor() {
+        write(terminal, CSI + "132$|");           // grow to 132 (non-destructive)
+        write(terminal, CSI + "1;1H");            // home
+        write(terminal, "A".repeat(100));         // fill cols 0-99; cursor ends at x=100
+        assertEquals(100, terminal.x, "precondition: cursor at col 100 (within 132)");
+        assertEquals('A', charAt(99, 0), "precondition: col 99 filled");
+
+        write(terminal, CSI + "80$|");            // DECSCPP -> 80 columns (shrink)
+
+        assertEquals(Terminal.WIDTH, terminal.getTerminalWidth(), "DECSCPP shrinks to 80 columns");
+        assertEquals(Terminal.WIDTH * Terminal.HEIGHT * Terminal.SCROLL_BACK_COUNT,
+            terminal.buffer.length, "buffers reallocate to 80 columns");
+        assertEquals('A', charAt(79, 0), "DECSCPP preserves the first 80 columns of content");
+        assertEquals(79, terminal.x, "DECSCPP clamps the cursor to the new rightmost column");
+        assertFalse(terminal.currentPrivateModeState.DECCOLM,
+            "DECSCPP clears the DECCOLM flag at 80 columns");
+    }
+
+    @Test
+    void decscppSetsDeccolmFlagToMatchWidth() {
+        write(terminal, CSI + "132$|");
+        assertTrue(terminal.currentPrivateModeState.DECCOLM, "132 cols sets the DECCOLM flag");
+        assertEquals(132, terminal.getTerminalWidth());
+
+        write(terminal, CSI + "80$|");
+        assertFalse(terminal.currentPrivateModeState.DECCOLM, "80 cols clears the DECCOLM flag");
+        assertEquals(Terminal.WIDTH, terminal.getTerminalWidth());
+    }
+
+    @Test
+    void decscppIgnoresIllegalParam() {
+        write(terminal, CSI + "132$|");           // 132
+        write(terminal, CSI + "100$|");           // 100 is neither 80 nor 132 -> ignored
+        assertEquals(132, terminal.getTerminalWidth(), "illegal DECSCPP param is a no-op");
+        assertTrue(terminal.currentPrivateModeState.DECCOLM, "DECCOLM flag unchanged on no-op");
+    }
+
+    @Test
+    void decscppBareParamDefaultsToEighty() {
+        write(terminal, CSI + "132$|");           // 132
+        write(terminal, CSI + "$|");              // bare -> default 80
+        assertEquals(Terminal.WIDTH, terminal.getTerminalWidth(),
+            "bare CSI $ | defaults to 80 columns");
+        assertFalse(terminal.currentPrivateModeState.DECCOLM, "80 cols clears the DECCOLM flag");
+    }
+
+    @Test
+    void decscppIgnoresPrivateMarkerPrefixes() {
+        // F2 (Kimi gate, 2026-09-07): xterm-410 routes "CSI ? Pn $ |" to CASE_GROUND_STATE
+        // (VTPrsTbl.c csi_dec_dollar_table[0x7C]); only the plain csi_dollar_table[0x7C] is
+        // DECSCPP, and the "> Pn $" form has no DECSCPP mapping either. The prefixed forms
+        // must be ignored, not treated as DECSCPP — more-permissive-than-xterm hides app bugs.
+        write(terminal, CSI + "?132$|");
+        assertEquals(Terminal.WIDTH, terminal.getTerminalWidth(),
+            "?-prefixed DECSCPP is ignored (xterm: ground state)");
+        assertFalse(terminal.currentPrivateModeState.DECCOLM, "DECCOLM flag untouched by ?-form");
+
+        write(terminal, CSI + ">132$|");
+        assertEquals(Terminal.WIDTH, terminal.getTerminalWidth(),
+            ">-prefixed DECSCPP is ignored");
+        assertFalse(terminal.currentPrivateModeState.DECCOLM, "DECCOLM flag untouched by >-form");
+
+        // The plain form still works after the ignored garbage.
+        write(terminal, CSI + "132$|");
+        assertEquals(132, terminal.getTerminalWidth(), "plain DECSCPP still applies");
+    }
+
+    @Test
+    void decscppPreservesTabStops() {
+        // Revert-and-fail: DECCOLM rebuilds default tab stops; DECSCPP preserves user-set stops
+        // in the surviving columns and default-fills only the new columns.
+        write(terminal, CSI + "4G");              // CHA: cursor to column 4 (x=3)
+        write(terminal, ESC + "H");               // HTS: set a tab stop at column 3
+        assertTrue(terminal.tabs[3], "precondition: custom tab stop at column 3");
+
+        write(terminal, CSI + "132$|");           // DECSCPP grow to 132
+
+        assertTrue(terminal.tabs[3], "DECSCPP preserves the user-set tab stop at column 3");
+        assertTrue(terminal.tabs[88], "new column 88 gets the default tab stop (88 % 8 == 0)");
+        assertFalse(terminal.tabs[85], "new column 85 has no tab stop (85 % 8 != 0)");
+    }
+
     private void write(final Terminal target, final String text) {
         target.io.putOutput(ByteBuffer.wrap(text.getBytes(StandardCharsets.UTF_8)));
     }
@@ -1543,7 +1669,7 @@ public class TerminalBufferTest {
     }
 
     private char altCharAt(final int x, final int y) {
-        return (char) terminal.altBuffer[x + y * Terminal.WIDTH];
+        return (char) terminal.altBuffer[x + y * terminal.width];
     }
 
     private void resetDirty() {

--- a/src/test/java/li/cil/oc2/common/vm/terminal/TerminalDiffTest.java
+++ b/src/test/java/li/cil/oc2/common/vm/terminal/TerminalDiffTest.java
@@ -248,6 +248,33 @@ public class TerminalDiffTest {
                 "RIS reset must restore the client's palette to default, not leave it stale");
     }
 
+    @Test
+    void decscppReshipsVisibleWindowSoClientSurvivesWidthChange() {
+        // F1 regression (Kimi gate, 2026-09-07): resizeWidth must mark the NETWORK sink, not
+        // just the renderer masks. DECSCPP is the first width path where the server PRESERVES
+        // content while the client's apply-side width change destructively reallocates
+        // (TerminalDiff.apply -> setWidth). If the snapshot ships width without rows, the
+        // client blanks (visible + scrollback) while the server keeps "HELLO" — divergence
+        // until the next captureFull. Revert-and-fail: drop markAllDirty() from resizeWidth
+        // and rows() comes back empty here, and the client's 'H' vanishes.
+        write(server, "HELLO");
+        final Terminal client = new Terminal();
+        TerminalDiff.apply(client, TerminalDiff.capture(server)); // drain: HELLO shipped + consumed
+        assertEquals('H', charAt(client, 0, 0), "precondition: client shows HELLO at 80 cols");
+        assertEquals(Terminal.WIDTH, client.getTerminalWidth(), "precondition: client at 80 cols");
+
+        write(server, CSI + "132$|"); // DECSCPP on the server (non-destructive there)
+        assertEquals(132, server.getTerminalWidth(), "precondition: server resized to 132");
+
+        final TerminalDiff.Snapshot snapshot = TerminalDiff.capture(server);
+        assertTrue(snapshot.rows().length > 0,
+            "DECSCPP must re-ship the visible window — a width-only snapshot blanks the client");
+        TerminalDiff.apply(client, snapshot);
+        assertEquals('H', charAt(client, 0, 0),
+            "client keeps the server's content across the DECSCPP width change");
+        assertEquals(132, client.getTerminalWidth(), "client is resized to 132 columns");
+    }
+
     private static void write(final Terminal target, final String text) {
         target.io.putOutput(ByteBuffer.wrap(text.getBytes(StandardCharsets.UTF_8)));
     }


### PR DESCRIPTION
Implements DECSCPP (Select Columns Per Page, `CSI Pn $ |`) — the non-destructive column-set the CH2 DECCOLM comment names as the modern replacement — plus the `Terminal.resizeWidth(int)` primitive it needs.

## What it does

`resizeWidth` copies existing contents into the surviving columns instead of clearing them, unlike `setWidth` (DECCOLM's destructive reset). Per DEC VT510-RM and xterm-410 `CASE_DECSCPP`:

| Resets | Preserves |
|---|---|
| — (nothing) | Screen contents + scrollback |
| | Scroll margins (DECSTBM) |
| | SGR rendition |
| | Tab stops (surviving columns) |
| | Active cursor (clamped only if beyond the new width) |

New columns are **default-initialized** (blank, default fg/bg, no style) — a resize is not a clear, so unlike `setWidth`'s erase-character fill (current SGR background) the new cells get defaults, matching xterm's `calloc`-zero on `Reallocate`. `setWidth` keeps its erase fill unchanged (its `TerminalDiff.apply` caller relies on it).

`CH13` is a new combined handler for the `|` final: `$ |` is DECSCPP (`0`/`80`→80, `132`→132, anything else ignored; sets the DECCOLM flag to match), `* |` is a DECSLPP stub (warn) — dynamic HEIGHT is a separate future axis, to be bundled with XTWINOPS case 8. The `?`/`>`-prefixed forms are ignored, matching xterm (`csi_dec_dollar_table` maps `|` to `CASE_GROUND_STATE`).

## Network seam

`resizeWidth` marks the network sink (`markAllDirty`) in addition to the renderer masks. DECSCPP is the first width path where the server *preserves* content while the client's `TerminalDiff.apply` responds to the width change with a destructive `setWidth` — without the mark, the snapshot ships width with zero rows and the client blanks (visible window + scrollback) while the server keeps its content, until the next `captureFull`. DECCOLM never hit this because its escape paths (CH2/CH3) already call `markAllDirty`. An adversarial review caught this; revert-and-fail proven (dropping the mark fails the new `TerminalDiffTest.decscppReshipsVisibleWindowSoClientSurvivesWidthChange`).

## Also in here

- `resolveEraseBackground()` extracted — the erase-color switch was duplicated verbatim in `setWidth` and `resizeWidth`; `setWidth` now calls it too.
- `TerminalBufferTest.altCharAt` uses the dynamic width as its stride (was hardcoded `Terminal.WIDTH` — latent once width became dynamic).
- `asterisk` intermediate parsed (`CSIState`/`CSIManager`) for the DECSLPP stub — no existing sequence used `*`.
- 1 SpotBugs baseline entry (resizeWidth's width-write `AT_STALE` — the same §36 M4 render race `setWidth` already has baselined; real fix remains the deferred M4 work).

## Known deviations from xterm (documented, deferred)

Tab stops in lost columns do not survive a shrink→grow cycle (xterm's fixed `MAX_TABS` array keeps them), and shrinking discards columns xterm's optional `OPT_RESIZE_ADJUST` build would restore on grow-back. Both match the VT510 language "columns beyond the new width are lost."

## Verification

- `./gradlew check` — BUILD SUCCESSFUL (test, checkstyle, pmd, spotbugs, lintRatchet; 325 tests, 0 failures). Rebased onto `upstream/work` @ `88feb1a2`, clean.
- 6 `TerminalBufferTest` cases (grow preserves content/margins/cursor/SGR with new columns default-initialized, shrink loses columns >80 and clamps the cursor, DECCOLM-flag agreement, illegal/bare params, tab-stop preservation, private-marker forms ignored) + the `TerminalDiffTest` seam regression.
- Adversarial review (Kimi K3, separate context): confirmed the stride/copy across the 480 scrollback rows, the ColorData replace-never-mutate discipline, the default-init split against xterm `screen.c` `allocScrnData`/`Reallocate`, and the autowrap-pending parity (`charproc.c:7192`). Caught the network-seam blocker above and the private-marker permissiveness; both fixed here, both revert-and-fail proven.

Assisted by: GLM (syn:large:text on synthetic.new) — code generation and review.